### PR TITLE
Use nio Path instead of File for log locations.

### DIFF
--- a/jvm/src/main/scala/scribe/writer/FileHandle.scala
+++ b/jvm/src/main/scala/scribe/writer/FileHandle.scala
@@ -1,17 +1,19 @@
 package scribe.writer
 
-import java.io.File
+import java.nio.file.Path
 import java.nio.file.{Files, StandardOpenOption}
 import java.util.concurrent.atomic.AtomicInteger
 
-class FileHandle(val file: File, append: Boolean) {
+class FileHandle(val file: Path, append: Boolean) {
   val references = new AtomicInteger(0)
 
   // Make sure the directories exist
-  file.getParentFile.mkdirs()
+  for (parent <- Option(file.getParent)) {
+    Files.createDirectories(parent)
+  }
 
   private val writer = Files.newBufferedWriter(
-    file.toPath,
+    file,
     if (append) StandardOpenOption.APPEND else StandardOpenOption.TRUNCATE_EXISTING,
     StandardOpenOption.CREATE,
     StandardOpenOption.WRITE
@@ -31,9 +33,9 @@ class FileHandle(val file: File, append: Boolean) {
 }
 
 object FileHandle {
-  private var map = Map.empty[File, FileHandle]
+  private var map = Map.empty[Path, FileHandle]
 
-  def apply(file: File, append: Boolean): FileHandle = synchronized {
+  def apply(file: Path, append: Boolean): FileHandle = synchronized {
     val h = map.get(file) match {
       case Some(handle) => handle
       case None => {

--- a/jvm/src/main/scala/scribe/writer/FileWriter.scala
+++ b/jvm/src/main/scala/scribe/writer/FileWriter.scala
@@ -1,12 +1,10 @@
 package scribe.writer
 
-import java.io.{BufferedOutputStream, File, FileOutputStream}
-import java.util.concurrent.atomic.AtomicInteger
-
+import java.nio.file.{Path, Paths}
 import scribe.LogRecord
 import scribe.formatter.Formatter
 
-class FileWriter(val directory: File,
+class FileWriter(val directory: Path,
                  val filenameGenerator: () => String,
                  val append: Boolean = true,
                  val autoFlush: Boolean = true) extends Writer {
@@ -19,11 +17,11 @@ class FileWriter(val directory: File,
       case Some(h) if currentFilename != filename => {
         FileHandle.release(h)
         currentFilename = filename
-        handle = Some(FileHandle(new File(directory, currentFilename), append))
+        handle = Some(FileHandle(directory.resolve(currentFilename), append))
       }
       case None => {
         currentFilename = filename
-        handle = Some(FileHandle(new File(directory, currentFilename), append))
+        handle = Some(FileHandle(directory.resolve(currentFilename), append))
       }
       case _ => // Ignore
     }
@@ -41,13 +39,13 @@ object FileWriter {
   def datePattern(pattern: String): () => String = () => pattern.format(System.currentTimeMillis())
 
   def daily(name: String = "application",
-            directory: File = new File("logs"),
+            directory: Path = Paths.get("logs"),
             append: Boolean = true,
             autoFlush: Boolean = true): FileWriter = {
     new FileWriter(directory, datePattern(name + ".%1$tY-%1$tm-%1$td.log"), append, autoFlush)
   }
   def flat(name: String = "application",
-           directory: File = new File("logs"),
+           directory: Path = Paths.get("logs"),
            append: Boolean = true,
            autoFlush: Boolean = true): FileWriter = new FileWriter(directory, () => s"$name.log", append, autoFlush)
 }

--- a/jvm/src/test/scala/spec/FileLoggingSpec.scala
+++ b/jvm/src/test/scala/spec/FileLoggingSpec.scala
@@ -1,36 +1,36 @@
 package spec
 
-import java.io.File
-
+import java.nio.file.{Files, Path, Paths}
 import scribe.formatter.Formatter
 import scribe.writer.FileWriter
 import scribe.{LogHandler, Logger}
 import org.scalatest.{Matchers, WordSpec}
 
 import scala.io.Source
-import scala.util.Try
 
 class FileLoggingSpec extends WordSpec with Matchers {
   lazy val fileLogger: Logger = Logger(parentName = None)
-  lazy val logFile: File = new File("logs/test.log")
+  lazy val logFile: Path = Paths.get("logs/test.log")
   lazy val writer: FileWriter = FileWriter.flat("test")
 
   "File Logging" should {
     "configure logging to a temporary file" in {
-      logFile.delete()
+      if (Files.exists(logFile)) {
+        Files.delete(logFile)
+      }
       fileLogger.addHandler(LogHandler(formatter = Formatter.simple, writer = writer))
     }
     "log to the file" in {
       fileLogger.info("Testing File Logger")
     }
     "verify the file was logged to" in {
-      logFile.exists() should be(true)
-      val source = Source.fromFile(logFile)
+      Files.exists(logFile) should be(true)
+      val source = Source.fromFile(logFile.toFile)
       try {
         source.mkString.trim should equal("Testing File Logger")
       } finally {
         source.close()
-        logFile.delete()
+        Files.delete(logFile)
       }
     }
     "close and release the file handle" in {


### PR DESCRIPTION
I prefer Path to File. I see Path is already used internally, so I suppose there is some reason to use File instead of Path for the public interface?

This is a breaking change.