### PR TITLE
add log method which takes message and throwable

### DIFF
--- a/shared/src/main/scala/scribe/Logger.scala
+++ b/shared/src/main/scala/scribe/Logger.scala
@@ -80,6 +80,10 @@ object Logger {
   }
   root.addHandler(LogHandler())
 
+  final def messageAndThrowable2String(message: String, t: Throwable): String = {
+    throwable2String(t, b = new StringBuilder(message).append(" - "))
+  }
+
   /**
     * Converts a Throwable to a String representation for output in logging.
     */

--- a/shared/src/main/scala/scribe/LoggerSupport.scala
+++ b/shared/src/main/scala/scribe/LoggerSupport.scala
@@ -18,12 +18,16 @@ trait LoggerSupport {
 
   def trace(t: => Throwable): Unit = macro Macros.traceThrowable
 
+  def trace(message: => String, t: => Throwable): Unit = macro Macros.traceMessageAndThrowable
+
   /**
     * Debug log entry. Uses Macros to optimize performance.
     */
   def debug(message: => Any): Unit = macro Macros.debug
 
   def debug(t: => Throwable): Unit = macro Macros.debugThrowable
+
+  def debug(message: => String, t: => Throwable): Unit = macro Macros.debugMessageAndThrowable
 
   /**
     * Info log entry. Uses Macros to optimize performance.
@@ -32,6 +36,8 @@ trait LoggerSupport {
 
   def info(t: => Throwable): Unit = macro Macros.infoThrowable
 
+  def info(message: => String, t: => Throwable): Unit = macro Macros.infoMessageAndThrowable
+
   /**
     * Warn log entry. Uses Macros to optimize performance.
     */
@@ -39,15 +45,16 @@ trait LoggerSupport {
 
   def warn(t: => Throwable): Unit = macro Macros.warnThrowable
 
+  def warn(message: => String, t: => Throwable): Unit = macro Macros.warnMessageAndThrowable
+
   /**
     * Error log entry. Uses Macros to optimize performance.
     */
   def error(message: => Any): Unit = macro Macros.error
 
-  /**
-    * Error log entry. Uses Macros to optimize performance.
-    */
   def error(t: => Throwable): Unit = macro Macros.errorThrowable
+
+  def error(message: => String, t: => Throwable): Unit = macro Macros.errorMessageAndThrowable
 
   /**
     * Log method invoked by trace, debug, info, warn, and error. Ideally should not be called directly as it will not

--- a/shared/src/main/scala/scribe/Macros.scala
+++ b/shared/src/main/scala/scribe/Macros.scala
@@ -48,11 +48,21 @@ object Macros {
     logSpecial(c)(c.universe.reify(Level.Trace), t, q"(v: Any) => scribe.Logger.throwable2String(v.asInstanceOf[Throwable])")
   }
 
+  def traceMessageAndThrowable(c: whitebox.Context)(message: c.Tree, t: c.Tree): c.universe.Tree = {
+    import c.universe._
+    logSpecial(c)(c.universe.reify(Level.Trace), q"($message, $t)", q"""{ case (m: String, t: Throwable) => scribe.Logger.messageAndThrowable2String(m, t) }""")
+  }
+
   def debug(c: whitebox.Context)(message: c.Tree): c.universe.Tree = log(c)(c.universe.reify(Level.Debug), message)
 
   def debugThrowable(c: whitebox.Context)(t: c.Tree): c.universe.Tree = {
     import c.universe._
     logSpecial(c)(c.universe.reify(Level.Debug), t, q"(v: Any) => scribe.Logger.throwable2String(v.asInstanceOf[Throwable])")
+  }
+
+  def debugMessageAndThrowable(c: whitebox.Context)(message: c.Tree, t: c.Tree): c.universe.Tree = {
+    import c.universe._
+    logSpecial(c)(c.universe.reify(Level.Debug), q"($message, $t)", q"""{ case (m: String, t: Throwable) => scribe.Logger.messageAndThrowable2String(m, t) }""")
   }
 
   def info(c: whitebox.Context)(message: c.Tree): c.universe.Tree = log(c)(c.universe.reify(Level.Info), message)
@@ -62,6 +72,11 @@ object Macros {
     logSpecial(c)(c.universe.reify(Level.Info), t, q"(v: Any) => scribe.Logger.throwable2String(v.asInstanceOf[Throwable])")
   }
 
+  def infoMessageAndThrowable(c: whitebox.Context)(message: c.Tree, t: c.Tree): c.universe.Tree = {
+    import c.universe._
+    logSpecial(c)(c.universe.reify(Level.Info), q"($message, $t)", q"""{ case (m: String, t: Throwable) => scribe.Logger.messageAndThrowable2String(m, t) }""")
+  }
+
   def warn(c: whitebox.Context)(message: c.Tree): c.universe.Tree = log(c)(c.universe.reify(Level.Warn), message)
 
   def warnThrowable(c: whitebox.Context)(t: c.Tree): c.universe.Tree = {
@@ -69,10 +84,20 @@ object Macros {
     logSpecial(c)(c.universe.reify(Level.Warn), t, q"(v: Any) => scribe.Logger.throwable2String(v.asInstanceOf[Throwable])")
   }
 
+  def warnMessageAndThrowable(c: whitebox.Context)(message: c.Tree, t: c.Tree): c.universe.Tree = {
+    import c.universe._
+    logSpecial(c)(c.universe.reify(Level.Warn), q"($message, $t)", q"""{ case (m: String, t: Throwable) => scribe.Logger.messageAndThrowable2String(m, t) }""")
+  }
+
   def error(c: whitebox.Context)(message: c.Tree): c.universe.Tree = log(c)(c.universe.reify(Level.Error), message)
 
   def errorThrowable(c: whitebox.Context)(t: c.Tree): c.universe.Tree = {
     import c.universe._
     logSpecial(c)(c.universe.reify(Level.Error), t, q"(v: Any) => scribe.Logger.throwable2String(v.asInstanceOf[Throwable])")
+  }
+
+  def errorMessageAndThrowable(c: whitebox.Context)(message: c.Tree, t: c.Tree): c.universe.Tree = {
+    import c.universe._
+    logSpecial(c)(c.universe.reify(Level.Error), q"($message, $t)", q"""{ case (m: String, t: Throwable) => scribe.Logger.messageAndThrowable2String(m, t) }""")
   }
 }

--- a/tests/shared/src/test/scala/specs/LoggingSpec.scala
+++ b/tests/shared/src/test/scala/specs/LoggingSpec.scala
@@ -51,6 +51,7 @@ class LoggingSpec extends WordSpec with Matchers with Logging {
       testingWriter.records.length should be(1)
       testingWriter.records.head.methodName should be(Some("testLogger"))
       testingWriter.records.head.lineNumber should be(lineNumber)
+      testingWriter.records.head.message should be("This is a test!")
     }
     "write an exception" in {
       val lineNumber = 16
@@ -60,6 +61,15 @@ class LoggingSpec extends WordSpec with Matchers with Logging {
       testingWriter.records.head.methodName should be(Some("testException"))
       testingWriter.records.head.lineNumber should be(lineNumber)
       testingWriter.records.head.message should startWith("java.lang.RuntimeException: Testing")
+    }
+    "write a message with an exception" in {
+      val lineNumber = 20
+      testingWriter.clear()
+      testObject.testLoggerException()
+      testingWriter.records.length should be(1)
+      testingWriter.records.head.methodName should be(Some("testLoggerException"))
+      testingWriter.records.head.lineNumber should be(lineNumber)
+      testingWriter.records.head.message should startWith("Oh no - java.lang.RuntimeException: Testing")
     }
   }
 }

--- a/tests/shared/src/test/scala/specs/LoggingTestObject.scala
+++ b/tests/shared/src/test/scala/specs/LoggingTestObject.scala
@@ -15,4 +15,8 @@ class LoggingTestObject(writer: TestingWriter) extends Logging {
   def testException(): Unit = {
     logger.info(new RuntimeException("Testing"))
   }
+
+  def testLoggerException(): Unit = {
+    logger.info("Oh no", new RuntimeException("Testing"))
+  }
 }


### PR DESCRIPTION
I often found myself wanting to log an exception with some contextual information. So I often have code like this:

```scala
case NonFatal(t) =>
  scribe.error(s"Tried something: $context")
  scribe.error(t) // this is not the same log line
  //or: scribe.error(scribe.Logger.throwable2String(t, b = new StringBuilder("Prefix - ")))
```

This PR introduces log methods accepting a message and a `Throwable`, where `throwable2String` is prefixed with the message. It can be used like this:
```scala
scribe.error("Hello", throwable) // Hello - $throwable
``` 