### PR TITLE
Update to the latest travis_setup.sh for Scala Native

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ scala:
 jdk:
   - oraclejdk8
 before_script:
-  - curl https://raw.githubusercontent.com/scala-native/scala-native/master/bin/travis_setup.sh | bash -x
+  - curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -x
 script:
   - sbt clean test
 cache:


### PR DESCRIPTION
[Recent PR](https://github.com/scala-native/scala-native/pull/1195) changed the location of the travis setup script within a Scala Native repo. This PR updates travis build to point to the new location.