### PR TITLE
make js source maps point to github repo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,15 @@ val scalaLoggingVersion: String = "3.9.0"
 val tinyLogVersion: String = "1.3.5"
 val log4sVersion: String = "1.6.1"
 
+// set source map paths from local directories to github path
+val sourceMapSettings = List(
+  scalacOptions ++= git.gitHeadCommit.value.map { headCommit =>
+    val local = baseDirectory.value.toURI
+    val remote = s"https://raw.githubusercontent.com/outr/scribe/${headCommit}/"
+    s"-P:scalajs:mapSourceURI:$local->$remote"
+  }
+)
+
 lazy val root = project.in(file("."))
   .aggregate(
     macrosJS, macrosJVM, macrosNative,
@@ -85,6 +94,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     ),
     publishArtifact in Test := false
   )
+  .jsSettings(sourceMapSettings)
   .nativeSettings(
     scalaVersion := "2.11.12",
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,3 +13,5 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.3")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("com.codacy" % "sbt-codacy-coverage" % "1.3.12")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")


### PR DESCRIPTION
This PR make the javascript source maps point to this github repo, instead of having local paths from your machine. It includes the current commit hash in order to have stable links.