### PR TITLE
add formatted time FormatBlock

### DIFF
--- a/core/shared/src/main/scala/scribe/format/FormatBlock.scala
+++ b/core/shared/src/main/scala/scribe/format/FormatBlock.scala
@@ -42,6 +42,10 @@ object FormatBlock {
     override def format[M](record: LogRecord[M]): String = record.timeStamp.toString
   }
 
+  object Time extends FormatBlock {
+    override def format[M](record: LogRecord[M]): String = p"${record.timeStamp.t.T}"
+  }
+
   object Date {
     object Standard extends FormatBlock {
       private lazy val cache = new ThreadLocal[String] {

--- a/core/shared/src/main/scala/scribe/format/package.scala
+++ b/core/shared/src/main/scala/scribe/format/package.scala
@@ -8,6 +8,7 @@ package object format {
 
   def date: FormatBlock = FormatBlock.Date.Standard
   def timeStamp: FormatBlock = FormatBlock.TimeStamp
+  def time: FormatBlock = FormatBlock.Time
   def threadName: FormatBlock = FormatBlock.ThreadName
   def threadNameAbbreviated: FormatBlock = threadName.abbreviate(
     maxLength = ThreadNameAbbreviationLength,


### PR DESCRIPTION
Makes sense for a daily filewriter. Though, I am not sure about the name, maybe `time`/`Time` is too generic and something like `timeStampFormatted` would be more explicit.