### PR TITLE
Some benchmark improvements.

### DIFF
--- a/benchmarks/src/main/resources/log4j2.xml
+++ b/benchmarks/src/main/resources/log4j2.xml
@@ -7,21 +7,21 @@
         </Console>
     </Appenders>
     <Appenders>
-        <File name="log4j" fileName="logs/log4j.log">
+        <RandomAccessFile name="log4j" fileName="logs/log4j.log" immediateFlush="false" append="false">
             <PatternLayout>
                 <Pattern>%d %p %c{1.} [%t] %m%n</Pattern>
             </PatternLayout>
-        </File>
-        <File name="log4s" fileName="logs/log4s.log">
+        </RandomAccessFile>
+        <RandomAccessFile name="log4s" fileName="logs/log4s.log" immediateFlush="false" append="false">
             <PatternLayout>
                 <Pattern>%d %p %c{1.} [%t] %m%n</Pattern>
             </PatternLayout>
-        </File>
-        <File name="TraceFile" fileName="logs/log4j-trace.log">
+        </RandomAccessFile>
+        <RandomAccessFile name="TraceFile" fileName="logs/log4j-trace.log" immediateFlush="false" append="false">
             <PatternLayout>
                 <Pattern>%d{ISO8601}{GMT} %-5p %C{2} (%F:%L) - %m%n</Pattern>
             </PatternLayout>
-        </File>
+        </RandomAccessFile>
         <Async name="Async">
             <AppenderRef ref="log4j"/>
         </Async>

--- a/benchmarks/src/main/scala/scribe/benchmark/LoggingSpeedBenchmark.scala
+++ b/benchmarks/src/main/scala/scribe/benchmark/LoggingSpeedBenchmark.scala
@@ -13,128 +13,149 @@ import scribe.handler.AsynchronousLogHandler
 
 // jmh:run -i 3 -wi 3 -f1 -t1 -rf JSON -rff benchmarks.json
 @annotations.State(annotations.Scope.Thread)
+@annotations.Fork(jvmArgs = Array("-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector"))
 class LoggingSpeedBenchmark {
   assert(LogManager.getRootLogger.isInfoEnabled, "INFO is not enabled in log4j!")
 
-  private lazy val asynchronousWriter = writer.FileWriter.simple("scribe-async.log")
-  private lazy val asynchronousHandler = AsynchronousLogHandler(Formatter.default, asynchronousWriter)
+  private var synchronousWriter: writer.FileWriter = _
+  private var synchronousLogger: Logger = _
 
-  @annotations.Setup(annotations.Level.Trial)
+  private var asynchronousWriter: writer.FileWriter = _
+  private var asynchronousHandler: AsynchronousLogHandler = _
+  private var asynchronousLogger: Logger = _
+
+  private var log4jLogger: org.apache.logging.log4j.Logger = _
+
+  private var log4jTraceLogger: org.apache.logging.log4j.Logger = _
+
+  private var log4sLogger: org.log4s.Logger = _
+
+  private var logbackLogger: org.slf4j.Logger = _
+
+  private var scalaLogger: sc.Logger = _
+
+  @annotations.Setup
   def doSetup(): Unit = {
     ConfigFactory.load()
+
     tinylog.Configurator
-      .defaultConfig()
-      .removeAllWriters()
-      .writer(new tinylog.writers.FileWriter("logs/tiny.log"))
-      .level(tinylog.Level.INFO)
-      .activate()
+    .defaultConfig()
+    .removeAllWriters()
+    .writer(new tinylog.writers.FileWriter("logs/tiny.log"))
+    .level(tinylog.Level.INFO)
+    .activate()
+
+    asynchronousWriter =  writer.FileWriter.simple("scribe-async.log")
+    asynchronousHandler = AsynchronousLogHandler(Formatter.default, asynchronousWriter)
+    asynchronousLogger = Logger.empty.orphan().withHandler(asynchronousHandler)
+
+    synchronousWriter = writer.FileWriter.simple("scribe.log")
+    synchronousLogger = Logger.empty.orphan().withHandler(writer = synchronousWriter)
+
+    log4jLogger = LogManager.getRootLogger
+    log4jTraceLogger = LogManager.getLogger("Trace")
+
+    log4sLogger = org.log4s.getLogger("scala")
+
+    logbackLogger = org.slf4j.LoggerFactory.getLogger("logback")
+
+    scalaLogger = sc.Logger("root")
   }
 
   @annotations.Benchmark
   @annotations.BenchmarkMode(Array(annotations.Mode.AverageTime))
-//  @annotations.BenchmarkMode(Array(annotations.Mode.AverageTime, annotations.Mode.SampleTime, annotations.Mode.Throughput))
+  //  @annotations.BenchmarkMode(Array(annotations.Mode.AverageTime, annotations.Mode.SampleTime, annotations.Mode.Throughput))
   @annotations.OutputTimeUnit(TimeUnit.NANOSECONDS)
   @annotations.OperationsPerInvocation(1000)
   def withScribe(): Unit = {
-    val fileWriter = writer.FileWriter.simple("scribe.log")
-    val logger = Logger.empty.orphan().withHandler(writer = fileWriter)
-
     var i = 0
     while (i < 1000) {
-      logger.info("test")
+      synchronousLogger.info("test")
       i += 1
     }
-    fileWriter.dispose()
   }
 
   @annotations.Benchmark
   @annotations.BenchmarkMode(Array(annotations.Mode.AverageTime))
-//  @annotations.BenchmarkMode(Array(annotations.Mode.AverageTime, annotations.Mode.SampleTime, annotations.Mode.Throughput))
+  //  @annotations.BenchmarkMode(Array(annotations.Mode.AverageTime, annotations.Mode.SampleTime, annotations.Mode.Throughput))
   @annotations.OutputTimeUnit(TimeUnit.NANOSECONDS)
   @annotations.OperationsPerInvocation(1000)
   def withScribeAsync(): Unit = {
-    val logger = Logger.empty.orphan().withHandler(asynchronousHandler)
-
     var i = 0
     while (i < 1000) {
-      logger.info("test")
+      asynchronousLogger.info("test")
       i += 1
     }
   }
 
   @annotations.Benchmark
   @annotations.BenchmarkMode(Array(annotations.Mode.AverageTime))
-//  @annotations.BenchmarkMode(Array(annotations.Mode.AverageTime, annotations.Mode.SampleTime, annotations.Mode.Throughput))
+  //  @annotations.BenchmarkMode(Array(annotations.Mode.AverageTime, annotations.Mode.SampleTime, annotations.Mode.Throughput))
   @annotations.OutputTimeUnit(TimeUnit.NANOSECONDS)
   @annotations.OperationsPerInvocation(1000)
   def withLog4j(): Unit = {
-    val logger = LogManager.getRootLogger
     var i = 0
     while (i < 1000) {
-      logger.info("test")
+      log4jLogger.info("test")
       i += 1
     }
   }
 
   @annotations.Benchmark
   @annotations.BenchmarkMode(Array(annotations.Mode.AverageTime))
-//  @annotations.BenchmarkMode(Array(annotations.Mode.AverageTime, annotations.Mode.SampleTime, annotations.Mode.Throughput))
+  //  @annotations.BenchmarkMode(Array(annotations.Mode.AverageTime, annotations.Mode.SampleTime, annotations.Mode.Throughput))
   @annotations.OutputTimeUnit(TimeUnit.NANOSECONDS)
   @annotations.OperationsPerInvocation(1000)
   def withLog4s(): Unit = {
-    val logger = org.log4s.getLogger("scala")
     var i = 0
     while (i < 1000) {
-      logger.info("test")
+      log4sLogger.info("test")
       i += 1
     }
   }
 
   @annotations.Benchmark
   @annotations.BenchmarkMode(Array(annotations.Mode.AverageTime))
-//  @annotations.BenchmarkMode(Array(annotations.Mode.AverageTime, annotations.Mode.SampleTime, annotations.Mode.Throughput))
+  //  @annotations.BenchmarkMode(Array(annotations.Mode.AverageTime, annotations.Mode.SampleTime, annotations.Mode.Throughput))
   @annotations.OutputTimeUnit(TimeUnit.NANOSECONDS)
   @annotations.OperationsPerInvocation(1000)
   def withLog4jTrace(): Unit = {
-    val logger = LogManager.getLogger("Trace")
     var i = 0
     while (i < 1000) {
-      logger.info("test")
+      log4jTraceLogger.info("test")
       i += 1
     }
   }
 
   @annotations.Benchmark
   @annotations.BenchmarkMode(Array(annotations.Mode.AverageTime))
-//  @annotations.BenchmarkMode(Array(annotations.Mode.AverageTime, annotations.Mode.SampleTime, annotations.Mode.Throughput))
+  //  @annotations.BenchmarkMode(Array(annotations.Mode.AverageTime, annotations.Mode.SampleTime, annotations.Mode.Throughput))
   @annotations.OutputTimeUnit(TimeUnit.NANOSECONDS)
   @annotations.OperationsPerInvocation(1000)
   def withScalaLogging(): Unit = {
-    val logger = sc.Logger("root")
     var i = 0
     while (i < 1000) {
-      logger.info("test")
+      scalaLogger.info("test")
       i += 1
     }
   }
 
   @annotations.Benchmark
   @annotations.BenchmarkMode(Array(annotations.Mode.AverageTime))
-//  @annotations.BenchmarkMode(Array(annotations.Mode.AverageTime, annotations.Mode.SampleTime, annotations.Mode.Throughput))
+  //  @annotations.BenchmarkMode(Array(annotations.Mode.AverageTime, annotations.Mode.SampleTime, annotations.Mode.Throughput))
   @annotations.OutputTimeUnit(TimeUnit.NANOSECONDS)
   @annotations.OperationsPerInvocation(1000)
   def withLogback(): Unit = {
-    val logger = org.slf4j.LoggerFactory.getLogger("logback")
     var i = 0
     while (i < 1000) {
-      logger.info("test")
+      logbackLogger.info("test")
       i += 1
     }
   }
 
   @annotations.Benchmark
   @annotations.BenchmarkMode(Array(annotations.Mode.AverageTime))
-//  @annotations.BenchmarkMode(Array(annotations.Mode.AverageTime, annotations.Mode.SampleTime, annotations.Mode.Throughput))
+  //  @annotations.BenchmarkMode(Array(annotations.Mode.AverageTime, annotations.Mode.SampleTime, annotations.Mode.Throughput))
   @annotations.OutputTimeUnit(TimeUnit.NANOSECONDS)
   @annotations.OperationsPerInvocation(1000)
   def withTinyLog(): Unit = {
@@ -147,7 +168,7 @@ class LoggingSpeedBenchmark {
 
   @annotations.Benchmark
   @annotations.BenchmarkMode(Array(annotations.Mode.AverageTime))
-//  @annotations.BenchmarkMode(Array(annotations.Mode.AverageTime, annotations.Mode.SampleTime, annotations.Mode.Throughput))
+  //  @annotations.BenchmarkMode(Array(annotations.Mode.AverageTime, annotations.Mode.SampleTime, annotations.Mode.Throughput))
   @annotations.OutputTimeUnit(TimeUnit.NANOSECONDS)
   @annotations.OperationsPerInvocation(1000)
   def withPrintLine(): Unit = {
@@ -160,6 +181,7 @@ class LoggingSpeedBenchmark {
 
   @annotations.TearDown
   def tearDown(): Unit = {
+    synchronousWriter.dispose()
     asynchronousWriter.dispose()
   }
 }


### PR DESCRIPTION
Move logger acquisition out of the benchmark methods and into a Setup method.

Enable async logging for log4j2. I thought just including the Disruptor jar was enough to do that, but it's not. 14x speedup for regular logger and 64x speedup for trace.

Before and after, which I ran with `jmh:run -i 5 -wi 10 -f1 -t1 -rf JSON -rff benchmarks.json`:

> [info] # Run complete. Total time: 00:02:32
[info] Benchmark                               Mode  Cnt      Score       Error  Units
[info] LoggingSpeedBenchmark.withLog4j         avgt    5   7385.325 ±  1648.339  ns/op
[info] LoggingSpeedBenchmark.withLog4jTrace    avgt    5  61592.498 ± 28139.187  ns/op
[info] LoggingSpeedBenchmark.withLog4s         avgt    5  38124.842 ±  7714.751  ns/op
[info] LoggingSpeedBenchmark.withLogback       avgt    5  44042.671 ±  3838.535  ns/op
[info] LoggingSpeedBenchmark.withPrintLine     avgt    5  45312.231 ± 33704.914  ns/op
[info] LoggingSpeedBenchmark.withScalaLogging  avgt    5  52173.400 ± 20511.603  ns/op
[info] LoggingSpeedBenchmark.withScribe        avgt    5   1000.674 ±    29.562  ns/op
[info] LoggingSpeedBenchmark.withScribeAsync   avgt    5     73.252 ±     2.777  ns/op
[info] LoggingSpeedBenchmark.withTinyLog       avgt    5  10483.946 ±  1050.459  ns/op
>
> [info] # Run complete. Total time: 00:02:32
[info] Benchmark                               Mode  Cnt      Score       Error  Units
[info] LoggingSpeedBenchmark.withLog4j         avgt    5    524.290 ±    18.433  ns/op
[info] LoggingSpeedBenchmark.withLog4jTrace    avgt    5    959.314 ±   110.947  ns/op
[info] LoggingSpeedBenchmark.withLog4s         avgt    5  39506.749 ±  5119.532  ns/op
[info] LoggingSpeedBenchmark.withLogback       avgt    5  41633.737 ±  2861.170  ns/op
[info] LoggingSpeedBenchmark.withPrintLine     avgt    5  39028.793 ± 14129.436  ns/op
[info] LoggingSpeedBenchmark.withScalaLogging  avgt    5  36399.867 ±  4559.278  ns/op
[info] LoggingSpeedBenchmark.withScribe        avgt    5    955.418 ±    59.406  ns/op
[info] LoggingSpeedBenchmark.withScribeAsync   avgt    5     70.282 ±     1.380  ns/op
[info] LoggingSpeedBenchmark.withTinyLog       avgt    5  10586.169 ±  1085.722  ns/op