### PR TITLE
Define timezone in tests

### DIFF
--- a/slf4j/src/test/scala/spec/SLF4JSpec.scala
+++ b/slf4j/src/test/scala/spec/SLF4JSpec.scala
@@ -1,5 +1,7 @@
 package spec
 
+import java.util.TimeZone
+
 import org.scalatest.{Matchers, WordSpec}
 import org.slf4j.{LoggerFactory, MDC}
 import scribe.handler.LogHandler
@@ -9,6 +11,8 @@ import scribe.writer.Writer
 import scribe.{Level, LogRecord, Logger}
 
 class SLF4JSpec extends WordSpec with Matchers {
+  TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+
   private var logs: List[LogRecord[_]] = Nil
   private var logOutput: List[String] = Nil
   private val recordHolder = LogHandler.default.withMinimumLevel(Level.Info).withWriter(new Writer {
@@ -46,25 +50,25 @@ class SLF4JSpec extends WordSpec with Matchers {
     "verify Scribe wrote value" in {
       logOutput.size should be(1)
       val s = logOutput.head
-      s should be("2018.11.16 07:49:51 INFO spec.SLF4JSpec - Hello World!")
+      s should be("2018.11.16 13:49:51 INFO spec.SLF4JSpec - Hello World!")
     }
     "use MDC" in {
       MDC.put("name", "John Doe")
       val logger = LoggerFactory.getLogger(getClass)
       logger.info("A generic name")
-      logOutput.head should be("2018.11.16 07:49:51 INFO spec.SLF4JSpec - A generic name (name: John Doe)")
+      logOutput.head should be("2018.11.16 13:49:51 INFO spec.SLF4JSpec - A generic name (name: John Doe)")
     }
     "clear MDC" in {
       MDC.clear()
       val logger = LoggerFactory.getLogger(getClass)
       logger.info("MDC cleared")
-      logOutput.head should be("2018.11.16 07:49:51 INFO spec.SLF4JSpec - MDC cleared")
+      logOutput.head should be("2018.11.16 13:49:51 INFO spec.SLF4JSpec - MDC cleared")
     }
     "make sure logging nulls doesn't error" in {
       val logger = LoggerFactory.getLogger(getClass)
       logger.error(null)
       logs.length should be(3)
-      logOutput.head should be("2018.11.16 07:49:51 ERROR spec.SLF4JSpec - null")
+      logOutput.head should be("2018.11.16 13:49:51 ERROR spec.SLF4JSpec - null")
     }
   }
 }

--- a/slf4j18/src/test/scala/spec/SLF4JSpec.scala
+++ b/slf4j18/src/test/scala/spec/SLF4JSpec.scala
@@ -1,5 +1,7 @@
 package spec
 
+import java.util.TimeZone
+
 import org.scalatest.{Matchers, WordSpec}
 import org.slf4j.{LoggerFactory, MDC}
 import scribe.handler.LogHandler
@@ -9,6 +11,8 @@ import scribe.writer.Writer
 import scribe.{Level, LogRecord, Logger}
 
 class SLF4JSpec extends WordSpec with Matchers {
+  TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+
   private var logs: List[LogRecord[_]] = Nil
   private var logOutput: List[String] = Nil
   private val recordHolder = LogHandler.default.withMinimumLevel(Level.Info).withWriter(new Writer {
@@ -46,25 +50,25 @@ class SLF4JSpec extends WordSpec with Matchers {
     "verify Scribe wrote value" in {
       logOutput.size should be(1)
       val s = logOutput.head
-      s should be("2018.11.16 07:49:51 INFO spec.SLF4JSpec - Hello World!")
+      s should be("2018.11.16 13:49:51 INFO spec.SLF4JSpec - Hello World!")
     }
     "use MDC" in {
       MDC.put("name", "John Doe")
       val logger = LoggerFactory.getLogger(getClass)
       logger.info("A generic name")
-      logOutput.head should be("2018.11.16 07:49:51 INFO spec.SLF4JSpec - A generic name (name: John Doe)")
+      logOutput.head should be("2018.11.16 13:49:51 INFO spec.SLF4JSpec - A generic name (name: John Doe)")
     }
     "clear MDC" in {
       MDC.clear()
       val logger = LoggerFactory.getLogger(getClass)
       logger.info("MDC cleared")
-      logOutput.head should be("2018.11.16 07:49:51 INFO spec.SLF4JSpec - MDC cleared")
+      logOutput.head should be("2018.11.16 13:49:51 INFO spec.SLF4JSpec - MDC cleared")
     }
     "make sure logging nulls doesn't error" in {
       val logger = LoggerFactory.getLogger(getClass)
       logger.error(null)
       logs.length should be(3)
-      logOutput.head should be("2018.11.16 07:49:51 ERROR spec.SLF4JSpec - null")
+      logOutput.head should be("2018.11.16 13:49:51 ERROR spec.SLF4JSpec - null")
     }
   }
 }


### PR DESCRIPTION
Define the timezone to be able to make the tests pass without any changes no matter the timezone your device define.