### PR TITLE
Introduce release-drafter to get commits into releases.

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,8 @@
+template: |
+  ## What’s Changed
+
+  $CHANGES
+categories:
+  - title: "🔧 Dependency updates"
+    labels:
+      - "dependencies"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,14 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hello! No worries if this isn't something you want, but I figured I'd
throw this up here to at least get your thoughts.

When Steward sends in prs for stuff, like it did for scribe for us this
morning in Metals https://github.com/scalameta/metals/pull/3205, I often
like to click the "GitHub Release Notes" link, especially when the
changes break the build. This gives a nice overview of commits that you
can glance through to easily hone in on one of them. There has been a
few times I've clicked this with scribe and it lead me to an empty
release page. This is an automated way to help out with this utilizing
https://github.com/release-drafter/release-drafter.

Is this something you'd consider adding?