### PR TITLE
add option for pretty-printing in JsonWriter

### DIFF
--- a/json/shared/src/main/scala/scribe/json/JsonWriter.scala
+++ b/json/shared/src/main/scala/scribe/json/JsonWriter.scala
@@ -8,7 +8,7 @@ import scribe.writer.Writer
 import perfolation._
 import fabric.rw._
 
-case class JsonWriter(writer: Writer) extends Writer {
+case class JsonWriter(writer: Writer, prettyPrint: Boolean = true) extends Writer {
   override def write[M](record: LogRecord[M], output: LogOutput, outputFormat: OutputFormat): Unit = {
     val l = record.timeStamp
     val trace = record.throwable.map(throwable2Trace)
@@ -30,7 +30,7 @@ case class JsonWriter(writer: Writer) extends Writer {
       time = s"${l.t.T}.${l.t.L}${l.t.z}"
     )
     val json = r.toValue
-    val jsonString = Json.format(json)
+    val jsonString = if (prettyPrint) Json.format(json) else json.toString
     writer.write(record, new TextOutput(jsonString), outputFormat)
   }
 


### PR DESCRIPTION
Allows us to print single-line json, instead of multiline.

I even think, no-pretty-printing could be the default. At least for me, Json logging means it is for machine usage and not for humans. And you can easily format your logs afterwards with, e.g. `jq`, if you really want to. But in this PR, I left the default behavior as is.