### PR TITLE
feat: allow to customize directory for FileWriter logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ logs/
 out/
 benchmarks.json
 lowered.hnir
+
+# metals + vscode dirs
+.bloop/
+.metals/
+.vscode/
+**/metals.sbt

--- a/fileModule/shared/src/main/scala/scribe/file/PathBuilder.scala
+++ b/fileModule/shared/src/main/scala/scribe/file/PathBuilder.scala
@@ -5,25 +5,34 @@ import scribe.file.path.PathPart
 import java.io.File
 import java.nio.file.Path
 
-case class PathBuilder(parts: List[PathPart]) {
+/**
+  * @param partsList of PathPart's which will be used to build the name of the logfile
+  * @param rootDir directory in which logs will be stored
+  */
+case class PathBuilder(parts: List[PathPart], rootDir: File = PathBuilder.DefaultRootDir) {
+  val rootDirPath = rootDir.getAbsolutePath()
+
   def before(writer: FileWriter): Unit = parts.foreach(_.before(writer))
   def after(writer: FileWriter): Unit = parts.foreach(_.after(writer))
 
   def file(timeStamp: Long): File = {
-    val path = parts.foldLeft(PathBuilder.DefaultPath)((previous, part) => part.current(previous, timeStamp))
+    val path = parts.foldLeft(rootDirPath)((previous, part) => part.current(previous, timeStamp))
     new File(path)
   }
 
   def iterator(): Iterator[File] = parts
-    .foldLeft(Iterator(PathBuilder.DefaultPath))((previous, part) => previous.flatMap(part.all))
+    .foldLeft(Iterator(rootDirPath))((previous, part) => previous.flatMap(part.all))
     .map(new File(_))
 
   def /(part: PathPart): PathBuilder = copy(parts ::: List(part))
 }
 
 object PathBuilder {
-  lazy val DefaultPath: String = new File("logs", "app.log").getAbsolutePath
+  lazy val DefaultRootDir: File = new File("logs", "app.log")
+  lazy val DefaultPath: String = DefaultRootDir.getAbsolutePath
   lazy val Default: PathBuilder = PathBuilder(List(PathPart.SetPath(DefaultPath)))
 
   def static(path: Path): PathBuilder = PathBuilder(List(PathPart.SetPath(path.toString)))
+  def static(fileName: Path, rootDir: Path): PathBuilder = PathBuilder(List(PathPart.SetPath(fileName.toString)), rootDir.toFile())
+  def static(parts: List[PathPart], rootDir: Path): PathBuilder = PathBuilder(parts, rootDir.toFile())
 }


### PR DESCRIPTION
Previously `PathBuilder` was always using hardcoded `PathBuilder.DefaultPath` https://github.com/outr/scribe/blob/ccd375e9c1e4a5e8c440b7a2b9481551d183de4d/fileModule/shared/src/main/scala/scribe/file/PathBuilder.scala#L8-L22

Now, it's possible to configure this directory.