### PR TITLE
3.9

### DIFF
--- a/benchmarks/src/main/scala/scribe/benchmark/LoggingStressTest.scala
+++ b/benchmarks/src/main/scala/scribe/benchmark/LoggingStressTest.scala
@@ -45,7 +45,7 @@ object LoggingStressTest {
   }
 
   def nullLogger(): Logger = Logger("nullLogger").orphan().withHandler(new LogHandler {
-    override def log[M](record: LogRecord[M]): Unit = logged += 1
+    override def log(record: LogRecord): Unit = logged += 1
   }).replace()
 
   def fileLogger(formatter: Formatter): Logger = {

--- a/benchmarks/src/main/scala/scribe/benchmark/PerformanceBenchmark.scala
+++ b/benchmarks/src/main/scala/scribe/benchmark/PerformanceBenchmark.scala
@@ -20,7 +20,7 @@ class PerformanceBenchmark {
   private lazy val logger = Logger.empty.orphan().withHandler(
     minimumLevel = Some(Level.Info),
     writer = new Writer {
-      override def write[M](record: LogRecord[M], output: LogOutput, outputFormat: OutputFormat): Unit = record.level match {
+      override def write(record: LogRecord, output: LogOutput, outputFormat: OutputFormat): Unit = record.level match {
         case Level.Debug => debug.incrementAndGet()
         case Level.Info => info.incrementAndGet()
         case Level.Error => error.incrementAndGet()

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ val scalaNativeVersions = scalaNot211Versions
 
 name := "scribe"
 ThisBuild / organization := "com.outr"
-ThisBuild / version := "3.8.3"
+ThisBuild / version := "3.9.0-SNAPSHOT"
 ThisBuild / scalaVersion := scala213
 ThisBuild / scalacOptions ++= Seq("-unchecked", "-deprecation")
 ThisBuild / javacOptions ++= Seq("-source", "1.8", "-target", "1.8")

--- a/cats/shared/src/main/scala/scribe/LoggerWrapper.scala
+++ b/cats/shared/src/main/scala/scribe/LoggerWrapper.scala
@@ -5,9 +5,9 @@ import scribe.message.LoggableMessage
 import sourcecode.{FileName, Line, Name, Pkg}
 
 class LoggerWrapper[F[_]](val wrapped: Logger, val sync: Sync[F]) extends Scribe[F] {
-  override def log[M](record: LogRecord[M]): F[Unit] = sync.delay(wrapped.log(record))
+  override def log(record: LogRecord): F[Unit] = sync.delay(wrapped.log(record))
 
-  override def log[M: Loggable](level: Level, message: => M, additionalMessages: List[LoggableMessage])
+  override def log(level: Level, messages: LoggableMessage*)
                                (implicit pkg: Pkg, fileName: FileName, name: Name, line: Line): F[Unit] =
-    sync.defer(super.log(level, message, additionalMessages)(implicitly[Loggable[M]], pkg, fileName, name, line))
+    sync.defer(super.log(level, messages: _*)(pkg, fileName, name, line))
 }

--- a/cats/shared/src/main/scala/scribe/ScribeImpl.scala
+++ b/cats/shared/src/main/scala/scribe/ScribeImpl.scala
@@ -5,10 +5,10 @@ import scribe.message.LoggableMessage
 import sourcecode.{FileName, Line, Name, Pkg}
 
 class ScribeImpl[F[_]](val sync: Sync[F]) extends AnyVal with Scribe[F] {
-  override def log[M](record: LogRecord[M]): F[Unit] = sync.delay(Logger(record.className).log(record))
+  override def log(record: LogRecord): F[Unit] = sync.delay(Logger(record.className).log(record))
 
-  override def log[M: Loggable](level: Level, message: => M, additionalMessages: List[LoggableMessage])
+  override def log(level: Level, messages: LoggableMessage*)
                                (implicit pkg: Pkg, fileName: FileName, name: Name, line: Line): F[Unit] =
-    sync.defer(log[M](LoggerSupport[M](level, message, additionalMessages, pkg, fileName, name, line)))
+    sync.defer(log(LoggerSupport(level, messages.toList, pkg, fileName, name, line)))
 }
 

--- a/cats/shared/src/test/scala/spec/ScribeSpec.scala
+++ b/cats/shared/src/test/scala/spec/ScribeSpec.scala
@@ -15,8 +15,8 @@ class ScribeSpec extends AsyncWordSpec with AsyncIOSpec with Matchers {
     Logger.root
       .clearHandlers()
       .withHandler(new LogHandler {
-        override def log[M](record: LogRecord[M]): Unit = synchronized {
-          messages = record.message.logOutput.plainText :: messages
+        override def log(record: LogRecord): Unit = synchronized {
+          messages = record.messages.map(_.logOutput.plainText) ::: messages
         }
       })
       .replace()

--- a/core/js/src/main/scala/scribe/writer/BrowserConsoleWriter.scala
+++ b/core/js/src/main/scala/scribe/writer/BrowserConsoleWriter.scala
@@ -5,6 +5,7 @@ import scribe._
 import scribe.output._
 import scribe.output.format.OutputFormat
 
+import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.scalajs.js
 
@@ -14,8 +15,8 @@ import scala.scalajs.js
 object BrowserConsoleWriter extends Writer {
   val args: ListBuffer[String] = ListBuffer.empty
 
-  override def write[M](record: LogRecord[M], output: LogOutput, outputFormat: OutputFormat): Unit = {
-    val b = new StringBuilder
+  override def write(record: LogRecord, output: LogOutput, outputFormat: OutputFormat): Unit = {
+    val b = new mutable.StringBuilder
     args.clear()
     outputFormat.begin(b.append(_))
     outputFormat(output, b.append(_))

--- a/core/jvm/src/main/scala/LogExample.scala
+++ b/core/jvm/src/main/scala/LogExample.scala
@@ -9,8 +9,7 @@ object LogExample extends App {
   logger.log(LogRecord(
     level = Level.Info,
     value = Level.Info.value,
-    message = new LazyMessage(() => "Some message"),
-    additionalMessages = Nil,
+    messages = List("Some message"),
     fileName = "file.scala",
     className = "Class",
     methodName = None,

--- a/core/jvm/src/main/scala/scribe/handler/AsynchronousLogHandle.scala
+++ b/core/jvm/src/main/scala/scribe/handler/AsynchronousLogHandle.scala
@@ -26,7 +26,7 @@ case class AsynchronousLogHandle(maxBuffer: Int = AsynchronousLogHandle.DefaultM
   private lazy val cached = new AtomicLong(0L)
 
   private lazy val queue = {
-    val q = new ConcurrentLinkedQueue[(LogHandlerBuilder, LogRecord[_])]
+    val q = new ConcurrentLinkedQueue[(LogHandlerBuilder, LogRecord)]
     val t = new Thread {
       setDaemon(true)
 
@@ -49,7 +49,7 @@ case class AsynchronousLogHandle(maxBuffer: Int = AsynchronousLogHandle.DefaultM
 
   def withOverflow(overflow: Overflow): AsynchronousLogHandle = copy(overflow = overflow)
 
-  override def log[M](handler: LogHandlerBuilder, record: LogRecord[M]): Unit = {
+  override def log(handler: LogHandlerBuilder, record: LogRecord): Unit = {
     val add = if (!cached.incrementIfLessThan(maxBuffer)) {
       overflow match {
         case Overflow.DropOld => {

--- a/core/jvm/src/test/scala/spec/AsynchronousLoggingSpec.scala
+++ b/core/jvm/src/test/scala/spec/AsynchronousLoggingSpec.scala
@@ -27,7 +27,7 @@ class AsynchronousLoggingSpec extends AnyWordSpec with Matchers {
       val logger = Logger.empty.orphan().withHandler(
         formatter = AsynchronousLoggingSpec.format,
         writer = new Writer {
-          override def write[M](record: LogRecord[M], output: LogOutput, outputFormat: OutputFormat): Unit = queue.add(output.plainText.trim)
+          override def write(record: LogRecord, output: LogOutput, outputFormat: OutputFormat): Unit = queue.add(output.plainText.trim)
         }
       )
 

--- a/core/shared/src/main/scala/scribe/LogRecordCreator.scala
+++ b/core/shared/src/main/scala/scribe/LogRecordCreator.scala
@@ -4,16 +4,15 @@ import scribe.message.{LoggableMessage, Message}
 import scribe.util.Time
 
 trait LogRecordCreator {
-  def apply[M](level: Level,
-               value: Double,
-               message: Message[M],
-               additionalMessages: List[LoggableMessage],
-               fileName: String,
-               className: String,
-               methodName: Option[String],
-               line: Option[Int],
-               column: Option[Int],
-               thread: Thread = Thread.currentThread(),
-               data: Map[String, () => Any] = Map.empty,
-               timeStamp: Long = Time()): LogRecord[M]
+  def apply(level: Level,
+            value: Double,
+            messages: List[LoggableMessage],
+            fileName: String,
+            className: String,
+            methodName: Option[String],
+            line: Option[Int],
+            column: Option[Int],
+            thread: Thread = Thread.currentThread(),
+            data: Map[String, () => Any] = Map.empty,
+            timeStamp: Long = Time()): LogRecord
 }

--- a/core/shared/src/main/scala/scribe/Loggable.scala
+++ b/core/shared/src/main/scala/scribe/Loggable.scala
@@ -9,16 +9,16 @@ trait Loggable[-T] {
   def apply(value: T): LogOutput
 }
 
-object Loggable {
-  implicit object StringLoggable extends Loggable[String] {
-    def apply(value: String): LogOutput = new TextOutput(value)
-  }
-
-  implicit object LogOutputLoggable extends Loggable[LogOutput] {
-    override def apply(value: LogOutput): LogOutput = value
-  }
-
-  implicit object ThrowableLoggable extends Loggable[Throwable] {
-    def apply(t: Throwable): LogOutput = LogRecord.throwable2LogOutput(EmptyOutput, t)
-  }
-}
+//object Loggable {
+//  implicit object StringLoggable extends Loggable[String] {
+//    def apply(value: String): LogOutput = new TextOutput(value)
+//  }
+//
+//  implicit object LogOutputLoggable extends Loggable[LogOutput] {
+//    override def apply(value: LogOutput): LogOutput = value
+//  }
+//
+//  implicit object ThrowableLoggable extends Loggable[Throwable] {
+//    def apply(t: Throwable): LogOutput = LogRecord.throwable2LogOutput(EmptyOutput, t)
+//  }
+//}

--- a/core/shared/src/main/scala/scribe/Loggable.scala
+++ b/core/shared/src/main/scala/scribe/Loggable.scala
@@ -9,16 +9,8 @@ trait Loggable[-T] {
   def apply(value: T): LogOutput
 }
 
-//object Loggable {
-//  implicit object StringLoggable extends Loggable[String] {
-//    def apply(value: String): LogOutput = new TextOutput(value)
-//  }
-//
-//  implicit object LogOutputLoggable extends Loggable[LogOutput] {
-//    override def apply(value: LogOutput): LogOutput = value
-//  }
-//
-//  implicit object ThrowableLoggable extends Loggable[Throwable] {
-//    def apply(t: Throwable): LogOutput = LogRecord.throwable2LogOutput(EmptyOutput, t)
-//  }
-//}
+object Loggable {
+  def apply[V](f: V => LogOutput): V => LoggableMessage = (v: V) => {
+    LoggableMessage[V](v)(f)
+  }
+}

--- a/core/shared/src/main/scala/scribe/LoggerSupport.scala
+++ b/core/shared/src/main/scala/scribe/LoggerSupport.scala
@@ -6,68 +6,46 @@ import scribe.message.{LoggableMessage, Message}
 import scala.language.experimental.macros
 
 trait LoggerSupport[F] extends Any {
-  def log[M](record: LogRecord[M]): F
+  def log(record: LogRecord): F
 
-  def log[M: Loggable](level: Level, message: => M, additionalMessages: List[LoggableMessage] = Nil)
-                      (implicit pkg: sourcecode.Pkg,
-                       fileName: sourcecode.FileName,
-                       name: sourcecode.Name,
-                       line: sourcecode.Line): F = {
-    log[M](LoggerSupport[M](level, message, additionalMessages, pkg, fileName, name, line))
+  def log(level: Level, messages: LoggableMessage*)
+         (implicit pkg: sourcecode.Pkg,
+          fileName: sourcecode.FileName,
+          name: sourcecode.Name,
+          line: sourcecode.Line): F = {
+    log(LoggerSupport(level, messages.toList, pkg, fileName, name, line))
   }
 
-  def trace()(implicit pkg: sourcecode.Pkg,
-              fileName: sourcecode.FileName,
-              name: sourcecode.Name,
-              line: sourcecode.Line): F = log[String](Level.Trace, "", Nil)
-  def debug()(implicit pkg: sourcecode.Pkg,
-              fileName: sourcecode.FileName,
-              name: sourcecode.Name,
-              line: sourcecode.Line): F = log[String](Level.Debug, "", Nil)
-  def info()(implicit pkg: sourcecode.Pkg,
-             fileName: sourcecode.FileName,
-             name: sourcecode.Name,
-             line: sourcecode.Line): F = log[String](Level.Info, "", Nil)
-  def warn()(implicit pkg: sourcecode.Pkg,
-             fileName: sourcecode.FileName,
-             name: sourcecode.Name,
-             line: sourcecode.Line): F = log[String](Level.Warn, "", Nil)
-  def error()(implicit pkg: sourcecode.Pkg,
-              fileName: sourcecode.FileName,
-              name: sourcecode.Name,
-              line: sourcecode.Line): F = log[String](Level.Error, "", Nil)
+  def trace(messages: LoggableMessage*)(implicit pkg: sourcecode.Pkg,
+                                        fileName: sourcecode.FileName,
+                                        name: sourcecode.Name,
+                                        line: sourcecode.Line): F = log(Level.Trace, messages: _*)
 
-  def trace[M : Loggable](message: => M, additionalMessages: LoggableMessage*)
-                         (implicit pkg: sourcecode.Pkg,
-                          fileName: sourcecode.FileName,
-                          name: sourcecode.Name,
-                          line: sourcecode.Line): F = log[M](Level.Trace, message, additionalMessages.toList)
-  def debug[M : Loggable](message: => M, additionalMessages: LoggableMessage*)
-                         (implicit pkg: sourcecode.Pkg,
-                          fileName: sourcecode.FileName,
-                          name: sourcecode.Name,
-                          line: sourcecode.Line): F = log[M](Level.Debug, message, additionalMessages.toList)
-  def info[M : Loggable](message: => M, additionalMessages: LoggableMessage*)
-                        (implicit pkg: sourcecode.Pkg,
-                         fileName: sourcecode.FileName,
-                         name: sourcecode.Name,
-                         line: sourcecode.Line): F = log[M](Level.Info, message, additionalMessages.toList)
-  def warn[M : Loggable](message: => M, additionalMessages: LoggableMessage*)
-                        (implicit pkg: sourcecode.Pkg,
-                         fileName: sourcecode.FileName,
-                         name: sourcecode.Name,
-                         line: sourcecode.Line): F = log[M](Level.Warn, message, additionalMessages.toList)
-  def error[M : Loggable](message: => M, additionalMessages: LoggableMessage*)
-                         (implicit pkg: sourcecode.Pkg,
-                          fileName: sourcecode.FileName,
-                          name: sourcecode.Name,
-                          line: sourcecode.Line): F = log[M](Level.Error, message, additionalMessages.toList)
+  def debug(messages: LoggableMessage*)(implicit pkg: sourcecode.Pkg,
+                                        fileName: sourcecode.FileName,
+                                        name: sourcecode.Name,
+                                        line: sourcecode.Line): F = log(Level.Debug, messages: _*)
+
+  def info(messages: LoggableMessage*)(implicit pkg: sourcecode.Pkg,
+                                       fileName: sourcecode.FileName,
+                                       name: sourcecode.Name,
+                                       line: sourcecode.Line): F = log(Level.Info, messages: _*)
+
+  def warn(messages: LoggableMessage*)(implicit pkg: sourcecode.Pkg,
+                                       fileName: sourcecode.FileName,
+                                       name: sourcecode.Name,
+                                       line: sourcecode.Line): F = log(Level.Warn, messages: _*)
+
+  def error(messages: LoggableMessage*)(implicit pkg: sourcecode.Pkg,
+                                        fileName: sourcecode.FileName,
+                                        name: sourcecode.Name,
+                                        line: sourcecode.Line): F = log(Level.Error, messages: _*)
 
   /**
-    * Includes MDC elapsed to show elapsed time within the block
-    *
-    * @param f the code block to time
-    */
+   * Includes MDC elapsed to show elapsed time within the block
+   *
+   * @param f the code block to time
+   */
   def elapsed[Return](f: => Return): Return = {
     val key = "elapsed"
     val exists = MDC.contains(key)
@@ -80,11 +58,11 @@ trait LoggerSupport[F] extends Any {
   }
 
   /**
-    * Contextualize key/value pairs set on MDC. This will be made avoid on each log record within
-    *
-    * @param keyValues tuples of key/value pairs to set on MDC
-    * @param f the context for which these MDC values are set
-    */
+   * Contextualize key/value pairs set on MDC. This will be made avoid on each log record within
+   *
+   * @param keyValues tuples of key/value pairs to set on MDC
+   * @param f         the context for which these MDC values are set
+   */
   def apply[Return](keyValues: (String, Any)*)(f: => Return): Return = {
     keyValues.foreach {
       case (key, value) => MDC.update(key, value)
@@ -100,14 +78,12 @@ trait LoggerSupport[F] extends Any {
 object LoggerSupport {
   private var map = Map.empty[sourcecode.Pkg, Map[sourcecode.FileName, (String, String)]]
 
-  def apply[M](level: Level,
-               message: => M,
-               additionalMessages: List[LoggableMessage],
-               pkg: sourcecode.Pkg,
-               fileName: sourcecode.FileName,
-               name: sourcecode.Name,
-               line: sourcecode.Line)
-              (implicit loggable: Loggable[M]): LogRecord[M] = {
+  def apply(level: Level,
+            messages: List[LoggableMessage],
+            pkg: sourcecode.Pkg,
+            fileName: sourcecode.FileName,
+            name: sourcecode.Name,
+            line: sourcecode.Line): LogRecord = {
     val (fn, className) = LoggerSupport.className(pkg, fileName)
     val methodName = name.value match {
       case "anonymous" | "" => None
@@ -116,8 +92,7 @@ object LoggerSupport {
     LogRecord(
       level = level,
       value = level.value,
-      message = Message(message),
-      additionalMessages = additionalMessages,
+      messages = messages,
       fileName = fn,
       className = className,
       methodName = methodName,

--- a/core/shared/src/main/scala/scribe/LoggingOutputStream.scala
+++ b/core/shared/src/main/scala/scribe/LoggingOutputStream.scala
@@ -1,16 +1,17 @@
 package scribe
 
 import java.io.OutputStream
+import scala.collection.mutable
 
 class LoggingOutputStream(loggerId: LoggerId,
                           level: Level,
                           className: String,
                           methodName: Option[String]) extends OutputStream {
-  private lazy val b = new StringBuilder
+  private lazy val b = new mutable.StringBuilder
 
   override def write(byte: Int): Unit = byte.toChar match {
     case '\n' => {
-      Logger(loggerId).logDirect(level, b.toString(), className = className, methodName = methodName)
+      Logger(loggerId).logDirect(level, List(b.toString()), className = className, methodName = methodName)
       b.clear()
     }
     case c => b.append(c)

--- a/core/shared/src/main/scala/scribe/filter/AndFilters.scala
+++ b/core/shared/src/main/scala/scribe/filter/AndFilters.scala
@@ -3,7 +3,7 @@ package scribe.filter
 import scribe.LogRecord
 
 case class AndFilters(filters: List[Filter]) extends Filter {
-  override def matches[M](record: LogRecord[M]): Boolean = filters.forall(_.matches(record))
+  override def matches(record: LogRecord): Boolean = filters.forall(_.matches(record))
 
   override def &&(that: Filter): Filter = copy(filters ::: List(that))
 }

--- a/core/shared/src/main/scala/scribe/filter/ClassNameFilter.scala
+++ b/core/shared/src/main/scala/scribe/filter/ClassNameFilter.scala
@@ -6,5 +6,5 @@ import scribe.LogRecord
   * Filter matcher based on the class name
   */
 object ClassNameFilter extends FilterMatcher {
-  override protected def string[M](record: LogRecord[M]): String = record.className
+  override protected def string(record: LogRecord): String = record.className
 }

--- a/core/shared/src/main/scala/scribe/filter/Filter.scala
+++ b/core/shared/src/main/scala/scribe/filter/Filter.scala
@@ -6,7 +6,7 @@ import scribe.LogRecord
   * Filter for use in FilterBuilder, which is a LogModifier
   */
 trait Filter {
-  def matches[M](record: LogRecord[M]): Boolean
+  def matches(record: LogRecord): Boolean
 
   def &&(that: Filter): Filter = AndFilters(List(this, that))
   def ||(that: Filter): Filter = OrFilters(List(this, that))

--- a/core/shared/src/main/scala/scribe/filter/FilterBuilder.scala
+++ b/core/shared/src/main/scala/scribe/filter/FilterBuilder.scala
@@ -34,7 +34,7 @@ case class FilterBuilder(priority: Priority = Priority.Normal,
 
   def priority(priority: Priority): FilterBuilder = copy(priority = priority)
 
-  override def apply[M](record: LogRecord[M]): Option[LogRecord[M]] = {
+  override def apply(record: LogRecord): Option[LogRecord] = {
     if (select.isEmpty || select.exists(_.matches(record))) {
       val incl = include.forall(_.matches(record))
       val excl = exclude.exists(_.matches(record))

--- a/core/shared/src/main/scala/scribe/filter/FilterMatcher.scala
+++ b/core/shared/src/main/scala/scribe/filter/FilterMatcher.scala
@@ -6,21 +6,21 @@ import scribe.LogRecord
   * Matcher for use with filters
   */
 trait FilterMatcher {
-  protected def string[M](record: LogRecord[M]): String
+  protected def string(record: LogRecord): String
 
   def apply(exact: String): Filter = new Filter {
-    override def matches[M](record: LogRecord[M]): Boolean = string(record) == exact
+    override def matches(record: LogRecord): Boolean = string(record) == exact
   }
   def contains(value: String): Filter = new Filter {
-    override def matches[M](record: LogRecord[M]): Boolean = string(record).contains(value)
+    override def matches(record: LogRecord): Boolean = string(record).contains(value)
   }
   def startsWith(value: String): Filter = new Filter {
-    override def matches[M](record: LogRecord[M]): Boolean = string(record).startsWith(value)
+    override def matches(record: LogRecord): Boolean = string(record).startsWith(value)
   }
   def endsWith(value: String): Filter = new Filter {
-    override def matches[M](record: LogRecord[M]): Boolean = string(record).endsWith(value)
+    override def matches(record: LogRecord): Boolean = string(record).endsWith(value)
   }
   def regex(regex: String): Filter = new Filter {
-    override def matches[M](record: LogRecord[M]): Boolean = string(record).matches(regex)
+    override def matches(record: LogRecord): Boolean = string(record).matches(regex)
   }
 }

--- a/core/shared/src/main/scala/scribe/filter/OrFilters.scala
+++ b/core/shared/src/main/scala/scribe/filter/OrFilters.scala
@@ -3,7 +3,7 @@ package scribe.filter
 import scribe.LogRecord
 
 case class OrFilters(filters: List[Filter]) extends Filter {
-  override def matches[M](record: LogRecord[M]): Boolean = filters.exists(_.matches(record))
+  override def matches(record: LogRecord): Boolean = filters.exists(_.matches(record))
 
   override def ||(that: Filter): Filter = copy(filters ::: List(that))
 }

--- a/core/shared/src/main/scala/scribe/filter/PackageNameFilter.scala
+++ b/core/shared/src/main/scala/scribe/filter/PackageNameFilter.scala
@@ -6,7 +6,7 @@ import scribe.LogRecord
   * Filters based on the package name
   */
 object PackageNameFilter extends FilterMatcher {
-  override protected def string[M](record: LogRecord[M]): String = {
+  override protected def string(record: LogRecord): String = {
     val index = record.className.lastIndexOf('.')
     if (index > 0) {
       record.className.substring(0, index)

--- a/core/shared/src/main/scala/scribe/format/AbbreviateBlock.scala
+++ b/core/shared/src/main/scala/scribe/format/AbbreviateBlock.scala
@@ -13,7 +13,7 @@ class AbbreviateBlock(block: FormatBlock,
     override def initialValue(): Map[String, TextOutput] = Map.empty
   }
 
-  override def format[M](record: LogRecord[M]): LogOutput = {
+  override def format(record: LogRecord): LogOutput = {
     val value = block.format(record).plainText
     val map = cache.get()
     map.get(value) match {

--- a/core/shared/src/main/scala/scribe/format/FormatBlocksFormatter.scala
+++ b/core/shared/src/main/scala/scribe/format/FormatBlocksFormatter.scala
@@ -4,7 +4,7 @@ import scribe.LogRecord
 import scribe.output.{CompositeOutput, LogOutput}
 
 class FormatBlocksFormatter(blocks: List[FormatBlock]) extends Formatter {
-  override def format[M](record: LogRecord[M]): LogOutput = {
+  override def format(record: LogRecord): LogOutput = {
     new CompositeOutput(blocks.map(_.format(record)))
   }
 

--- a/core/shared/src/main/scala/scribe/format/Formatter.scala
+++ b/core/shared/src/main/scala/scribe/format/Formatter.scala
@@ -4,7 +4,7 @@ import scribe.LogRecord
 import scribe.output.LogOutput
 
 trait Formatter {
-  def format[M](record: LogRecord[M]): LogOutput
+  def format(record: LogRecord): LogOutput
 }
 
 object Formatter {

--- a/core/shared/src/main/scala/scribe/format/RightPaddingBlock.scala
+++ b/core/shared/src/main/scala/scribe/format/RightPaddingBlock.scala
@@ -4,7 +4,7 @@ import scribe.LogRecord
 import scribe.output.{LogOutput, TextOutput}
 
 class RightPaddingBlock(block: FormatBlock, length: Int, padding: Char) extends FormatBlock {
-  override def format[M](record: LogRecord[M]): LogOutput = {
+  override def format(record: LogRecord): LogOutput = {
     val value = block.format(record).plainText
     new TextOutput(value.padTo(length, " ").mkString)
   }

--- a/core/shared/src/main/scala/scribe/format/package.scala
+++ b/core/shared/src/main/scala/scribe/format/package.scala
@@ -13,7 +13,7 @@ package object format {
   private val PositionAbbreviationLength = 25
 
   case object empty extends FormatBlock {
-    override def format[M](record: LogRecord[M]): LogOutput = EmptyOutput
+    override def format(record: LogRecord): LogOutput = EmptyOutput
   }
   lazy val space: FormatBlock = string(" ")
   lazy val openBracket: FormatBlock = string("[")

--- a/core/shared/src/main/scala/scribe/handler/FunctionalLogHandler.scala
+++ b/core/shared/src/main/scala/scribe/handler/FunctionalLogHandler.scala
@@ -3,10 +3,10 @@ package scribe.handler
 import scribe.LogRecord
 import scribe.modify.LogModifier
 
-case class FunctionalLogHandler(f: LogRecord[_] => Unit, modifiers: List[LogModifier]) extends LogHandler {
+case class FunctionalLogHandler(f: LogRecord => Unit, modifiers: List[LogModifier]) extends LogHandler {
   def setModifiers(modifiers: List[LogModifier]): LogHandler = copy(modifiers = modifiers.sorted)
 
-  override def log[M](record: LogRecord[M]): Unit = {
+  override def log(record: LogRecord): Unit = {
     modifiers.foldLeft(Option(record))((r, lm) => r.flatMap(lm.apply)).foreach { r =>
       f(r)
     }

--- a/core/shared/src/main/scala/scribe/handler/LogHandle.scala
+++ b/core/shared/src/main/scala/scribe/handler/LogHandle.scala
@@ -3,5 +3,5 @@ package scribe.handler
 import scribe.LogRecord
 
 trait LogHandle {
-  def log[M](handler: LogHandlerBuilder, record: LogRecord[M]): Unit
+  def log(handler: LogHandlerBuilder, record: LogRecord): Unit
 }

--- a/core/shared/src/main/scala/scribe/handler/LogHandler.scala
+++ b/core/shared/src/main/scala/scribe/handler/LogHandler.scala
@@ -13,7 +13,7 @@ import scribe.{Level, LogRecord}
  * `withHandler` method that takes a `Formatter` and `Writer` instead of defining a `LogHandler` manually.
  */
 trait LogHandler {
-  def log[M](record: LogRecord[M]): Unit
+  def log(record: LogRecord): Unit
 }
 
 object LogHandler {
@@ -27,7 +27,7 @@ object LogHandler {
     LogHandlerBuilder(formatter, writer, outputFormat, mods, handle)
   }
 
-  def apply(minimumLevel: Level)(f: LogRecord[_] => Unit): FunctionalLogHandler = {
+  def apply(minimumLevel: Level)(f: LogRecord => Unit): FunctionalLogHandler = {
     FunctionalLogHandler(f, List(LevelFilter >= minimumLevel))
   }
 }

--- a/core/shared/src/main/scala/scribe/handler/LogHandlerBuilder.scala
+++ b/core/shared/src/main/scala/scribe/handler/LogHandlerBuilder.scala
@@ -11,7 +11,7 @@ case class LogHandlerBuilder(formatter: Formatter = Formatter.default,
                              outputFormat: OutputFormat = OutputFormat.default,
                              modifiers: List[LogModifier] = Nil,
                              handle: LogHandle = SynchronousLogHandle) extends LogHandler {
-  override def log[M](record: LogRecord[M]): Unit = handle.log(this, record)
+  override def log(record: LogRecord): Unit = handle.log(this, record)
 
   def withFormatter(formatter: Formatter): LogHandlerBuilder = copy(formatter = formatter)
 

--- a/core/shared/src/main/scala/scribe/handler/SynchronousLogHandle.scala
+++ b/core/shared/src/main/scala/scribe/handler/SynchronousLogHandle.scala
@@ -7,7 +7,7 @@ import scribe.output.format.OutputFormat
 import scribe.writer.{ConsoleWriter, Writer}
 
 object SynchronousLogHandle extends LogHandle {
-  def log[M](handler: LogHandlerBuilder, record: LogRecord[M]): Unit = {
+  def log(handler: LogHandlerBuilder, record: LogRecord): Unit = {
     record.modify(handler.modifiers).foreach { r =>
       val logOutput = handler.formatter.format(r)
       handler.writer.write(record, logOutput, handler.outputFormat)

--- a/core/shared/src/main/scala/scribe/jul/JULHandler.scala
+++ b/core/shared/src/main/scala/scribe/jul/JULHandler.scala
@@ -1,6 +1,5 @@
 package scribe.jul
 
-import scribe.Loggable.StringLoggable
 import scribe.message.Message
 import scribe._
 
@@ -13,8 +12,7 @@ object JULHandler extends java.util.logging.Handler {
     val logRecord = LogRecord(
       level = level,
       value = level.value,
-      message = Message(record.getMessage),
-      additionalMessages = Option(record.getThrown).toList,
+      messages = List(record.getMessage),
       fileName = "",
       className = Option(record.getSourceClassName).getOrElse(record.getLoggerName),
       methodName = Option(record.getSourceMethodName),

--- a/core/shared/src/main/scala/scribe/message/EmptyMessage.scala
+++ b/core/shared/src/main/scala/scribe/message/EmptyMessage.scala
@@ -5,5 +5,5 @@ import scribe.output.LogOutput
 
 object EmptyMessage extends Message[String] {
   override val value: String = ""
-  override val logOutput: LogOutput = Loggable.StringLoggable(value)
+  override val logOutput: LogOutput = value
 }

--- a/core/shared/src/main/scala/scribe/message/EmptyMessage.scala
+++ b/core/shared/src/main/scala/scribe/message/EmptyMessage.scala
@@ -1,9 +1,8 @@
 package scribe.message
 
-import scribe.Loggable
-import scribe.output.LogOutput
+import scribe.output.{EmptyOutput, LogOutput}
 
 object EmptyMessage extends Message[String] {
   override val value: String = ""
-  override val logOutput: LogOutput = value
+  override val logOutput: LogOutput = EmptyOutput
 }

--- a/core/shared/src/main/scala/scribe/message/LoggableMessage.scala
+++ b/core/shared/src/main/scala/scribe/message/LoggableMessage.scala
@@ -19,5 +19,7 @@ object LoggableMessage {
     list.map(f => throwable2Message(f))
 
   def apply[V](value: => V)(toLogOutput: V => LogOutput): LoggableMessage =
-    new LazyMessage[V](() => value)(toLogOutput(_))
+    new LazyMessage[V](() => value)(new Loggable[V] {
+      override def apply(value: V): LogOutput = toLogOutput(value)
+    })
 }

--- a/core/shared/src/main/scala/scribe/message/LoggableMessage.scala
+++ b/core/shared/src/main/scala/scribe/message/LoggableMessage.scala
@@ -5,6 +5,7 @@ import scribe.output.LogOutput
 import scala.language.implicitConversions
 
 trait LoggableMessage {
+  def value: Any
   def logOutput: LogOutput
 }
 

--- a/core/shared/src/main/scala/scribe/message/Message.scala
+++ b/core/shared/src/main/scala/scribe/message/Message.scala
@@ -6,8 +6,8 @@ trait Message[M] extends LoggableMessage {
   override def value: M
 }
 
-object Message {
-  def static[M: Loggable](value: M): Message[M] = StaticMessage(value)
-  def apply[M: Loggable](value: => M): Message[M] = new LazyMessage[M](() => value)
-  def empty: Message[String] = EmptyMessage
-}
+//object Message {
+//  def static[M: Loggable](value: M): Message[M] = StaticMessage(value)
+//  def apply[M: Loggable](value: => M): Message[M] = new LazyMessage[M](() => value)
+//  def empty: Message[String] = EmptyMessage
+//}

--- a/core/shared/src/main/scala/scribe/message/Message.scala
+++ b/core/shared/src/main/scala/scribe/message/Message.scala
@@ -3,7 +3,7 @@ package scribe.message
 import scribe.Loggable
 
 trait Message[M] extends LoggableMessage {
-  def value: M
+  override def value: M
 }
 
 object Message {

--- a/core/shared/src/main/scala/scribe/modify/LevelFilter.scala
+++ b/core/shared/src/main/scala/scribe/modify/LevelFilter.scala
@@ -14,13 +14,13 @@ case class LevelFilter(include: Double => Boolean,
     i && !e
   }
 
-  override def apply[M](record: LogRecord[M]): Option[LogRecord[M]] = if (accepts(if (ignoreBoost) record.level.value else record.levelValue)) {
+  override def apply(record: LogRecord): Option[LogRecord] = if (accepts(if (ignoreBoost) record.level.value else record.levelValue)) {
     Some(record)
   } else {
     None
   }
 
-  override def matches[M](record: LogRecord[M]): Boolean = accepts(if (ignoreBoost) record.level.value else record.levelValue)
+  override def matches(record: LogRecord): Boolean = accepts(if (ignoreBoost) record.level.value else record.levelValue)
 
   override def withId(id: String): LogModifier = copy(id = id)
 }

--- a/core/shared/src/main/scala/scribe/modify/LogBooster.scala
+++ b/core/shared/src/main/scala/scribe/modify/LogBooster.scala
@@ -5,7 +5,7 @@ import scribe.{LogRecord, Priority}
 case class LogBooster(booster: Double => Double,
                       priority: Priority,
                       id: String = LogBooster.Id) extends LogModifier {
-  override def apply[M](record: LogRecord[M]): Option[LogRecord[M]] = Some(record.boost(booster))
+  override def apply(record: LogRecord): Option[LogRecord] = Some(record.boost(booster))
 
   override def withId(id: String): LogModifier = copy(id = id)
 }

--- a/core/shared/src/main/scala/scribe/modify/LogModifier.scala
+++ b/core/shared/src/main/scala/scribe/modify/LogModifier.scala
@@ -22,10 +22,9 @@ trait LogModifier {
    * Handles modification of a LogRecord
    *
    * @param record the record to modify
-   * @tparam M the type of message
    * @return Some LogRecord that should continue to propagate or None if the logging action should be canceled
    */
-  def apply[M](record: LogRecord[M]): Option[LogRecord[M]]
+  def apply(record: LogRecord): Option[LogRecord]
 
   def withId(id: String): LogModifier
 

--- a/core/shared/src/main/scala/scribe/package.scala
+++ b/core/shared/src/main/scala/scribe/package.scala
@@ -10,11 +10,11 @@ package object scribe extends LoggerSupport[Unit] {
   protected[scribe] var disposables = Set.empty[() => Unit]
 
   @inline
-  override final def log[M](record: LogRecord[M]): Unit = Logger(record.className).log(record)
+  override final def log(record: LogRecord): Unit = Logger(record.className).log(record)
 
-  override def log[M: Loggable](level: Level, message: => M, additionalMessages: List[Message])
+  override def log(level: Level, messages: Message*)
                                (implicit pkg: Pkg, fileName: FileName, name: Name, line: Line): Unit =
-    if (includes(level)) super.log(level, message, additionalMessages)
+    if (includes(level)) super.log(level, messages: _*)
 
   def includes(level: Level)(implicit pkg: sourcecode.Pkg,
                              fileName: sourcecode.FileName,

--- a/core/shared/src/main/scala/scribe/record/SimpleLogRecord.scala
+++ b/core/shared/src/main/scala/scribe/record/SimpleLogRecord.scala
@@ -4,10 +4,9 @@ import scribe.message.{LoggableMessage, Message}
 import scribe.{Level, LogRecord, LogRecordCreator}
 import scribe.output.{CompositeOutput, LogOutput}
 
-class SimpleLogRecord[M](val level: Level,
+class SimpleLogRecord(val level: Level,
                          val levelValue: Double,
-                         val message: Message[M],
-                         val additionalMessages: List[LoggableMessage],
+                         val messages: List[LoggableMessage],
                          val fileName: String,
                          val className: String,
                          val methodName: Option[String],
@@ -15,19 +14,12 @@ class SimpleLogRecord[M](val level: Level,
                          val column: Option[Int],
                          val thread: Thread,
                          val data: Map[String, () => Any],
-                         val timeStamp: Long) extends LogRecord[M] {
-  override lazy val logOutput: LogOutput = {
-    val msg = message.logOutput
-    additionalMessages match {
-      case Nil => msg
-      case list => new CompositeOutput(msg :: LogOutput.NewLine :: list.map(_.logOutput))
-    }
-  }
+                         val timeStamp: Long) extends LogRecord {
+  override lazy val logOutput: LogOutput = generateLogOutput()
 
   def copy(level: Level = level,
            value: Double = levelValue,
-           message: Message[M] = message,
-           additionalMessages: List[LoggableMessage] = additionalMessages,
+           messages: List[LoggableMessage] = messages,
            fileName: String = fileName,
            className: String = className,
            methodName: Option[String] = methodName,
@@ -35,8 +27,8 @@ class SimpleLogRecord[M](val level: Level,
            column: Option[Int] = column,
            thread: Thread = thread,
            data: Map[String, () => Any] = data,
-           timeStamp: Long = timeStamp): LogRecord[M] = {
-    val r = new SimpleLogRecord(level, value, message, additionalMessages, fileName, className, methodName, line, column, thread, data, timeStamp)
+           timeStamp: Long = timeStamp): LogRecord = {
+    val r = new SimpleLogRecord(level, value, messages, fileName, className, methodName, line, column, thread, data, timeStamp)
     r.appliedModifierIds = this.appliedModifierIds
     r
   }
@@ -45,10 +37,9 @@ class SimpleLogRecord[M](val level: Level,
 }
 
 object SimpleLogRecord extends LogRecordCreator {
-  override def apply[M](level: Level,
+  override def apply(level: Level,
                         value: Double,
-                        message: Message[M],
-                        additionalMessages: List[LoggableMessage],
+                        messages: List[LoggableMessage],
                         fileName: String,
                         className: String,
                         methodName: Option[String],
@@ -56,7 +47,7 @@ object SimpleLogRecord extends LogRecordCreator {
                         column: Option[Int],
                         thread: Thread,
                         data: Map[String, () => Any],
-                        timeStamp: Long): LogRecord[M] = {
-    new SimpleLogRecord(level, value, message, additionalMessages, fileName, className, methodName, line, column, thread, data, timeStamp)
+                        timeStamp: Long): LogRecord = {
+    new SimpleLogRecord(level, value, messages, fileName, className, methodName, line, column, thread, data, timeStamp)
   }
 }

--- a/core/shared/src/main/scala/scribe/writer/CacheWriter.scala
+++ b/core/shared/src/main/scala/scribe/writer/CacheWriter.scala
@@ -4,15 +4,15 @@ import scribe.output.LogOutput
 import scribe.output.format.OutputFormat
 
 class CacheWriter(max: Int = CacheWriter.DefaultMax) extends Writer {
-  private var recordCache = List.empty[LogRecord[Any]]
+  private var recordCache = List.empty[LogRecord]
   private var outputCache = List.empty[LogOutput]
 
-  override def write[M](record: LogRecord[M], output: LogOutput, outputFormat: OutputFormat): Unit = synchronized {
-    recordCache = (record.asInstanceOf[LogRecord[Any]] :: recordCache).take(max)
+  override def write(record: LogRecord, output: LogOutput, outputFormat: OutputFormat): Unit = synchronized {
+    recordCache = (record :: recordCache).take(max)
     outputCache = (output :: outputCache).take(max)
   }
 
-  def records: List[LogRecord[Any]] = recordCache
+  def records: List[LogRecord] = recordCache
   def output: List[LogOutput] = outputCache
 
   def clear(): Unit = synchronized {

--- a/core/shared/src/main/scala/scribe/writer/ConsoleWriter.scala
+++ b/core/shared/src/main/scala/scribe/writer/ConsoleWriter.scala
@@ -5,7 +5,7 @@ import scribe.output._
 import scribe.output.format.OutputFormat
 
 object ConsoleWriter extends Writer {
-  override def write[M](record: LogRecord[M], output: LogOutput, outputFormat: OutputFormat): Unit = {
-    Platform.consoleWriter.write[M](record, output, outputFormat)
+  override def write(record: LogRecord, output: LogOutput, outputFormat: OutputFormat): Unit = {
+    Platform.consoleWriter.write(record, output, outputFormat)
   }
 }

--- a/core/shared/src/main/scala/scribe/writer/NullWriter.scala
+++ b/core/shared/src/main/scala/scribe/writer/NullWriter.scala
@@ -5,5 +5,5 @@ import scribe.output.LogOutput
 import scribe.output.format.OutputFormat
 
 object NullWriter extends Writer {
-  override def write[M](record: LogRecord[M], output: LogOutput, outputFormat: OutputFormat): Unit = {}
+  override def write(record: LogRecord, output: LogOutput, outputFormat: OutputFormat): Unit = {}
 }

--- a/core/shared/src/main/scala/scribe/writer/SystemErrWriter.scala
+++ b/core/shared/src/main/scala/scribe/writer/SystemErrWriter.scala
@@ -8,6 +8,6 @@ import scribe.{LogRecord, Logger}
  * SystemErrWriter writes logs to System.err
  */
 object SystemErrWriter extends Writer {
-  override def write[M](record: LogRecord[M], output: LogOutput, outputFormat: OutputFormat): Unit =
+  override def write(record: LogRecord, output: LogOutput, outputFormat: OutputFormat): Unit =
     SystemWriter.write(Logger.system.err, output, outputFormat)
 }

--- a/core/shared/src/main/scala/scribe/writer/SystemOutWriter.scala
+++ b/core/shared/src/main/scala/scribe/writer/SystemOutWriter.scala
@@ -8,6 +8,6 @@ import scribe.{LogRecord, Logger}
  * SystemOutWriter writes logs to System.out
  */
 object SystemOutWriter extends Writer {
-  override def write[M](record: LogRecord[M], output: LogOutput, outputFormat: OutputFormat): Unit =
+  override def write(record: LogRecord, output: LogOutput, outputFormat: OutputFormat): Unit =
     SystemWriter.write(Logger.system.out, output, outputFormat)
 }

--- a/core/shared/src/main/scala/scribe/writer/SystemWriter.scala
+++ b/core/shared/src/main/scala/scribe/writer/SystemWriter.scala
@@ -32,13 +32,13 @@ object SystemWriter extends Writer {
     override def initialValue(): StringBuilder = new StringBuilder(stringBuilderStartCapacity)
   }
 
-  override def write[M](record: LogRecord[M], output: LogOutput, outputFormat: OutputFormat): Unit = {
+  override def write(record: LogRecord, output: LogOutput, outputFormat: OutputFormat): Unit = {
     val stream = if (record.level <= Level.Info) {
       Logger.system.out
     } else {
       Logger.system.err
     }
-    write[M](stream, output, outputFormat)
+    write(stream, output, outputFormat)
   }
 
   def write[M](stream: PrintStream, output: LogOutput, outputFormat: OutputFormat): Unit = {

--- a/core/shared/src/main/scala/scribe/writer/Writer.scala
+++ b/core/shared/src/main/scala/scribe/writer/Writer.scala
@@ -5,7 +5,7 @@ import scribe.output.LogOutput
 import scribe.output.format.OutputFormat
 
 trait Writer {
-  def write[M](record: LogRecord[M], output: LogOutput, outputFormat: OutputFormat): Unit
+  def write(record: LogRecord, output: LogOutput, outputFormat: OutputFormat): Unit
 
   def dispose(): Unit = {}
 }

--- a/core/shared/src/test/scala/specs/LoggingSpec.scala
+++ b/core/shared/src/test/scala/specs/LoggingSpec.scala
@@ -10,6 +10,7 @@ import scribe.data._
 import scribe.filter._
 import scribe.format.{FormatBlock, Formatter}
 import scribe.handler.{LogHandler, SynchronousLogHandle}
+import scribe.message.LoggableMessage
 import scribe.modify.{LevelFilter, LogBooster}
 import scribe.output.format.{HTMLOutputFormat, OutputFormat}
 import scribe.output.{LogOutput, TextOutput}
@@ -403,9 +404,8 @@ class LoggingSpec extends AnyWordSpec with Matchers with Logging {
         }
       })
 
-      implicit val loggableUser: Loggable[User] = new Loggable[User] {
-        override def apply(value: User): LogOutput = new TextOutput(s"{name: ${value.name}, age: ${value.age}}")
-      }
+      implicit val loggableUser: User => LoggableMessage =
+        Loggable[User](u => new TextOutput(s"{name: ${u.name}, age: ${u.age}}"))
 
       logger.info(User("John Doe", 21))
 

--- a/core/shared/src/test/scala/specs/LoggingSpec.scala
+++ b/core/shared/src/test/scala/specs/LoggingSpec.scala
@@ -404,8 +404,10 @@ class LoggingSpec extends AnyWordSpec with Matchers with Logging {
         }
       })
 
-      implicit val loggableUser: User => LoggableMessage =
-        Loggable[User](u => new TextOutput(s"{name: ${u.name}, age: ${u.age}}"))
+      // TODO: Surely we can make this better...
+      implicit def loggableUser(user: User): LoggableMessage = LoggableMessage[User](user) { u =>
+        new TextOutput(s"{name: ${u.name}, age: ${u.age}}")
+      }
 
       logger.info(User("John Doe", 21))
 

--- a/core/shared/src/test/scala/specs/LoggingSpec.scala
+++ b/core/shared/src/test/scala/specs/LoggingSpec.scala
@@ -122,7 +122,7 @@ class LoggingSpec extends AnyWordSpec with Matchers with Logging {
       val logger = Logger.empty.withHandler(
         formatter = LoggingSpec.mdcFormatter,
         writer = new Writer {
-          override def write[M](record: LogRecord[M], output: LogOutput, outputFormat: OutputFormat): Unit = logs += output.plainText
+          override def write(record: LogRecord, output: LogOutput, outputFormat: OutputFormat): Unit = logs += output.plainText
         }
       )
 
@@ -150,7 +150,7 @@ class LoggingSpec extends AnyWordSpec with Matchers with Logging {
       val logger = Logger.empty.withHandler(
         formatter = Formatter.simple,
         writer = new Writer {
-          override def write[M](record: LogRecord[M], output: LogOutput, outputFormat: OutputFormat): Unit = logs += output.plainText
+          override def write(record: LogRecord, output: LogOutput, outputFormat: OutputFormat): Unit = logs += output.plainText
         }
       )
 
@@ -178,7 +178,7 @@ class LoggingSpec extends AnyWordSpec with Matchers with Logging {
       val logger = Logger.empty.withHandler(
         formatter = Formatter.simple,
         writer = new Writer {
-          override def write[M](record: LogRecord[M], output: LogOutput, outputFormat: OutputFormat): Unit = logs += output.plainText
+          override def write(record: LogRecord, output: LogOutput, outputFormat: OutputFormat): Unit = logs += output.plainText
         }
       )
 
@@ -214,7 +214,7 @@ class LoggingSpec extends AnyWordSpec with Matchers with Logging {
         evaluated.incrementAndGet().toString
       }
       Logger("once").withHandler(new LogHandler {
-        override def log[M](record: LogRecord[M]): Unit = {
+        override def log(record: LogRecord): Unit = {
           // A handler must exist
         }
       }).replace()
@@ -245,14 +245,14 @@ class LoggingSpec extends AnyWordSpec with Matchers with Logging {
         .withHandler(
           formatter = Formatter.simple,
           writer = new Writer {
-            override def write[M](record: LogRecord[M], output: LogOutput, outputFormat: OutputFormat): Unit = logs += output.plainText
+            override def write(record: LogRecord, output: LogOutput, outputFormat: OutputFormat): Unit = logs += output.plainText
           }
         )
-      logger.logDirect(Level.Warn, "Included", className = "org.apache.flink.api.Included")
+      logger.logDirect(Level.Warn, List("Included"), className = "org.apache.flink.api.Included")
       logs.toList should be(List("Included"))
-      logger.logDirect(Level.Info, "Excluded", className = "org.apache.flink.api.Excluded")
+      logger.logDirect(Level.Info, List("Excluded"), className = "org.apache.flink.api.Excluded")
       logs.toList should be(List("Included"))
-      logger.logDirect(Level.Info, "Ignored", className = "test.Ignored")
+      logger.logDirect(Level.Info, List("Ignored"), className = "test.Ignored")
       logs.toList should be(List("Included", "Ignored"))
     }
     "boost via DSL" in {
@@ -267,15 +267,15 @@ class LoggingSpec extends AnyWordSpec with Matchers with Logging {
         .withHandler(
           formatter = Formatter.simple,
           writer = new Writer {
-            override def write[M](record: LogRecord[M], output: LogOutput, outputFormat: OutputFormat): Unit = logs += output.plainText
+            override def write(record: LogRecord, output: LogOutput, outputFormat: OutputFormat): Unit = logs += output.plainText
           },
           minimumLevel = Some(Level.Info)
         )
-      logger.logDirect(Level.Warn, "Included 1", className = "org.apache.flink.api.Included")
+      logger.logDirect(Level.Warn, List("Included 1"), className = "org.apache.flink.api.Included")
       logs.toList should be(List("Included 1"))
-      logger.logDirect(Level.Trace, "Included 2", className = "org.apache.flink.api.Included")
+      logger.logDirect(Level.Trace, List("Included 2"), className = "org.apache.flink.api.Included")
       logs.toList should be(List("Included 1", "Included 2"))
-      logger.logDirect(Level.Trace, "Excluded", className = "org.apache.flink.Excluded")
+      logger.logDirect(Level.Trace, List("Excluded"), className = "org.apache.flink.Excluded")
       logs.toList should be(List("Included 1", "Included 2"))
     }
     "multiple filters via DSL" in {
@@ -293,17 +293,17 @@ class LoggingSpec extends AnyWordSpec with Matchers with Logging {
         .withHandler(
           formatter = Formatter.simple,
           writer = new Writer {
-            override def write[M](record: LogRecord[M], output: LogOutput, outputFormat: OutputFormat): Unit = logs += output.plainText
+            override def write(record: LogRecord, output: LogOutput, outputFormat: OutputFormat): Unit = logs += output.plainText
           },
           minimumLevel = Some(Level.Info)
         )
-      logger.logDirect(Level.Debug, "Included 1", className = "org.package1.Included")
+      logger.logDirect(Level.Debug, List("Included 1"), className = "org.package1.Included")
       logs.toList should be(List("Included 1"))
-      logger.logDirect(Level.Debug, "Included 2", className = "org.package2.Included")
+      logger.logDirect(Level.Debug, List("Included 2"), className = "org.package2.Included")
       logs.toList should be(List("Included 1", "Included 2"))
-      logger.logDirect(Level.Info, "Excluded 1", className = "org.package3.Excluded")
+      logger.logDirect(Level.Info, List("Excluded 1"), className = "org.package3.Excluded")
       logs.toList should be(List("Included 1", "Included 2"))
-      logger.logDirect(Level.Error, "Included 3", className = "org.package3.Included")
+      logger.logDirect(Level.Error, List("Included 3"), className = "org.package3.Included")
       logs.toList should be(List("Included 1", "Included 2", "Included 3"))
     }
     "validate minimum level override support" in {
@@ -316,7 +316,7 @@ class LoggingSpec extends AnyWordSpec with Matchers with Logging {
       }
 
       val parent = Logger.empty.orphan().withMinimumLevel(Level.Error).withHandler(new LogHandler {
-        override def log[M](record: LogRecord[M]): Unit = {
+        override def log(record: LogRecord): Unit = {
           logged = record.logOutput.plainText :: logged
         }
       }).replace()
@@ -336,7 +336,7 @@ class LoggingSpec extends AnyWordSpec with Matchers with Logging {
       val h = LogHandler(
         minimumLevel = Some(Level.Info),
         writer = new Writer {
-          override def write[M](record: LogRecord[M], output: LogOutput, outputFormat: OutputFormat): Unit = records = record.message.value.toString :: records
+          override def write(record: LogRecord, output: LogOutput, outputFormat: OutputFormat): Unit = records = record.messages.map(_.logOutput.plainText).mkString(" ") :: records
         },
         modifiers = List(
           select(
@@ -365,7 +365,7 @@ class LoggingSpec extends AnyWordSpec with Matchers with Logging {
         .orphan()
         .withMinimumLevel(Level.Info)
         .withHandler(new LogHandler {
-          override def log[M](record: LogRecord[M]): Unit = records = record.logOutput.plainText :: records
+          override def log(record: LogRecord): Unit = records = record.logOutput.plainText :: records
         })
         .replace()
       Logger("com.example1").withParent(base.id).withModifier(boosted(Level.Trace, Level.Info)).replace()
@@ -397,7 +397,7 @@ class LoggingSpec extends AnyWordSpec with Matchers with Logging {
 
       case class User(name: String, age: Int)
       val logger = Logger().orphan().withHandler(new LogHandler {
-        override def log[M](record: LogRecord[M]): Unit = record.message.value match {
+        override def log(record: LogRecord): Unit = record.messages.head.value match {
           case u: User => logged = u :: logged
           case _ => // Ignore others
         }
@@ -416,7 +416,7 @@ class LoggingSpec extends AnyWordSpec with Matchers with Logging {
 
       case class User(name: String, age: Int)
       val logger = Logger().orphan().withHandler(new LogHandler {
-        override def log[M](record: LogRecord[M]): Unit = MDC.get("user").foreach {
+        override def log(record: LogRecord): Unit = MDC.get("user").foreach {
           case u: User => logged = u :: logged
         }
       })
@@ -432,7 +432,7 @@ class LoggingSpec extends AnyWordSpec with Matchers with Logging {
 
       case class User(name: String, age: Int)
       val logger = Logger().orphan().withHandler(new LogHandler {
-        override def log[M](record: LogRecord[M]): Unit = record.get("user").foreach {
+        override def log(record: LogRecord): Unit = record.get("user").foreach {
           case u: User => logged = u :: logged
         }
       })
@@ -462,7 +462,7 @@ class LoggingSpec extends AnyWordSpec with Matchers with Logging {
       Time.contextualize(MomentInTime) {
         val b = new StringBuilder
         val writer = new Writer {
-          override def write[M](record: LogRecord[M], output: LogOutput, outputFormat: OutputFormat): Unit = {
+          override def write(record: LogRecord, output: LogOutput, outputFormat: OutputFormat): Unit = {
             outputFormat(output, b.append(_))
           }
         }

--- a/core/shared/src/test/scala/specs/TestingHandler.scala
+++ b/core/shared/src/test/scala/specs/TestingHandler.scala
@@ -7,9 +7,9 @@ import scribe.{LogRecord, Priority}
 import scala.collection.mutable.ListBuffer
 
 class TestingHandler() extends LogHandler {
-  val records: ListBuffer[LogRecord[_]] = ListBuffer.empty[LogRecord[_]]
+  val records: ListBuffer[LogRecord] = ListBuffer.empty[LogRecord]
 
-  override def log[M](record: LogRecord[M]): Unit = records += record
+  override def log(record: LogRecord): Unit = records += record
 
   def clear(): Unit = records.clear()
 }

--- a/fileModule/shared/src/main/scala/scribe/file/FileWriter.scala
+++ b/fileModule/shared/src/main/scala/scribe/file/FileWriter.scala
@@ -28,7 +28,7 @@ case class FileWriter(pathBuilder: PathBuilder = PathBuilder.Default,
     _file = newFile
   }
 
-  override def write[M](record: LogRecord[M], output: LogOutput, outputFormat: OutputFormat): Unit = synchronized {
+  override def write(record: LogRecord, output: LogOutput, outputFormat: OutputFormat): Unit = synchronized {
     pathBuilder.before(this)
 
     // Write to LogFile

--- a/json/shared/src/test/scala/spec/JsonWriterSpec.scala
+++ b/json/shared/src/test/scala/spec/JsonWriterSpec.scala
@@ -27,7 +27,7 @@ class JsonWriterSpec extends AnyWordSpec with Matchers {
       json("date").asString should be("2021-01-01")
       json("line").asInt should be(24)
       json("fileName").asString should be("JsonWriterSpec.scala")
-      json("message").asString should be("Hello, Json!")
+      json("messages").asVector.map(_.asString) should be(Vector("Hello, Json!"))
     }
   }
 }

--- a/log4j/src/main/scala/scribe/ScribeProvider.scala
+++ b/log4j/src/main/scala/scribe/ScribeProvider.scala
@@ -6,6 +6,7 @@ import org.apache.logging.log4j.message.MessageFactory
 import org.apache.logging.log4j.spi.{AbstractLogger, CleanableThreadContextMap, ExtendedLogger, LoggerContext, LoggerContextFactory, LoggerRegistry, Provider}
 import org.apache.logging.log4j.util.{SortedArrayStringMap, StringMap}
 import scribe.data.MDC
+import scribe.message.LoggableMessage
 
 import scala.jdk.CollectionConverters._
 import java.net.URI
@@ -155,9 +156,11 @@ case class Log4JLogger(id: LoggerId) extends AbstractLogger {
                           marker: Marker,
                           message: org.apache.logging.log4j.message.Message,
                           t: Throwable): Unit = logger.log(
-    level = l2l(level).getOrElse(throw new RuntimeException(s"Unsupported level: $level")),
-    message = message.getFormattedMessage,
-    additionalMessages = Option(t).toList
+    l2l(level).getOrElse(throw new RuntimeException(s"Unsupported level: $level")),
+    (Some(LoggableMessage.string2Message(message.getFormattedMessage))
+      :: Option(t).map(LoggableMessage.throwable2Message(_))
+      :: Nil
+    ).flatten: _*
   )
 
   override def getLevel: log4j.Level = if (logger.includes(Level.Trace)) {

--- a/logstash/src/main/scala/scribe/logstash/LogstashRecord.scala
+++ b/logstash/src/main/scala/scribe/logstash/LogstashRecord.scala
@@ -2,11 +2,10 @@ package scribe.logstash
 
 import fabric.rw._
 
-case class LogstashRecord(message: String,
+case class LogstashRecord(messages: List[String],
                           service: String,
                           level: String,
                           value: Double,
-                          additionalMessages: List[String],
                           fileName: String,
                           className: String,
                           methodName: Option[String],

--- a/slack/src/main/scala/scribe/slack/SlackWriter.scala
+++ b/slack/src/main/scala/scribe/slack/SlackWriter.scala
@@ -12,7 +12,7 @@ import scribe.writer.Writer
   * @param emojiIcon the emoji to use when sending messages
   */
 class SlackWriter(slack: Slack, emojiIcon: String) extends Writer {
-  override def write[M](record: LogRecord[M], output: LogOutput, outputFormat: OutputFormat): Unit = slack.request(
+  override def write(record: LogRecord, output: LogOutput, outputFormat: OutputFormat): Unit = slack.request(
     message = output.plainText,
     emojiIcon = emojiIcon
   )

--- a/slf4j/src/main/scala/scribe/slf4j/SLF4JHelper.scala
+++ b/slf4j/src/main/scala/scribe/slf4j/SLF4JHelper.scala
@@ -3,7 +3,6 @@ package scribe.slf4j
 import org.slf4j.helpers.FormattingTuple
 import org.slf4j.spi.LocationAwareLogger
 import scribe.{Level, LogRecord}
-import scribe.Loggable.StringLoggable
 import scribe.message.Message
 
 object SLF4JHelper {
@@ -20,8 +19,7 @@ object SLF4JHelper {
     val record = LogRecord(
       level = level,
       value = level.value,
-      message = Message.static(msg),
-      additionalMessages = t.toList,
+      messages = List(msg),
       fileName = "",
       className = name,
       methodName = None,

--- a/slf4j/src/test/scala/spec/SLF4JSpec.scala
+++ b/slf4j/src/test/scala/spec/SLF4JSpec.scala
@@ -17,10 +17,10 @@ import scribe.{Level, LogRecord, Logger}
 class SLF4JSpec extends AnyWordSpec with Matchers {
   TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
 
-  private var logs: List[LogRecord[_]] = Nil
+  private var logs: List[LogRecord] = Nil
   private var logOutput: List[String] = Nil
   private val writer = new Writer {
-    override def write[M](record: LogRecord[M], output: LogOutput, outputFormat: OutputFormat): Unit = {
+    override def write(record: LogRecord, output: LogOutput, outputFormat: OutputFormat): Unit = {
       logs = record :: logs
       logOutput = output.plainText :: logOutput
     }

--- a/slf4j2/src/main/scala/scribe/slf4j/SLF4JHelper.scala
+++ b/slf4j2/src/main/scala/scribe/slf4j/SLF4JHelper.scala
@@ -2,7 +2,6 @@ package scribe.slf4j
 
 import org.slf4j.helpers.FormattingTuple
 import org.slf4j.spi.LocationAwareLogger
-import scribe.Loggable.StringLoggable
 import scribe.message.Message
 import scribe.{Level, LogRecord}
 
@@ -20,8 +19,7 @@ object SLF4JHelper {
     val record = LogRecord(
       level = level,
       value = level.value,
-      message = Message.static(msg),
-      additionalMessages = t.toList,
+      messages = List(msg),
       fileName = "",
       className = name,
       methodName = None,

--- a/slf4j2/src/test/scala/spec/SLF4JSpec.scala
+++ b/slf4j2/src/test/scala/spec/SLF4JSpec.scala
@@ -17,10 +17,10 @@ import scribe.{Level, LogRecord, Logger}
 class SLF4JSpec extends AnyWordSpec with Matchers {
   TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
 
-  private var logs: List[LogRecord[_]] = Nil
+  private var logs: List[LogRecord] = Nil
   private var logOutput: List[String] = Nil
   private val writer = new Writer {
-    override def write[M](record: LogRecord[M], output: LogOutput, outputFormat: OutputFormat): Unit = {
+    override def write(record: LogRecord, output: LogOutput, outputFormat: OutputFormat): Unit = {
       logs = record :: logs
       logOutput = output.plainText :: logOutput
     }


### PR DESCRIPTION
Refactored `LogRecord` to contain `messages` instead of `message` and `additionalMessages`. Also, removed generic type off of `LogRecord`. Surprisingly, performance appears to have improved as a result.