### PR TITLE
Attempt to enable JS sourcemaps for scala3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,9 +84,10 @@ val fs2Version: String = "3.2.9"
 // set source map paths from local directories to github path
 val sourceMapSettings = List(
   scalacOptions ++= git.gitHeadCommit.value.map { headCommit =>
+    val compilerJsSourceMapFlag = if (scalaVersion.value.startsWith("2.")) "-P:scalajs:mapSourceURI" else "-scalajs-mapSourceURI"    
     val local = baseDirectory.value.toURI
     val remote = s"https://raw.githubusercontent.com/outr/scribe/$headCommit/"
-    s"-P:scalajs:mapSourceURI:$local->$remote"
+    s"$compilerJsSourceMapFlag:$local->$remote"
   }
 )
 


### PR DESCRIPTION
Change the JS source maps compiler flag, depending on the scala version.

Please be aware; I haven't tested this (and don't really know how to) and my sbt-fu is weak. 

With all those caveats in mind, I believe this commit to be at least close to the solution, which I totally stole from here :-); 
https://github.com/raquo/Laminar/blob/739cc0dbab319c685f28be30a1592b7d04347842/build.sbt#L79