### PR TITLE
Added ANSI and ASCII support when running Scala.js under Node.js

### DIFF
--- a/core/js/src/main/scala/scribe/Platform.scala
+++ b/core/js/src/main/scala/scribe/Platform.scala
@@ -1,15 +1,19 @@
 package scribe
 
-import scribe.output.format.{OutputFormat, RichBrowserOutputFormat}
+import scribe.output.format.{ANSIOutputFormat, ASCIIOutputFormat, OutputFormat, RichBrowserOutputFormat}
 import scribe.writer.{BrowserConsoleWriter, Writer}
 
 import scala.concurrent.ExecutionContext
 import scala.scalajs.js
+import scala.scalajs.js.Dictionary
+import scala.util.Try
 
 object Platform extends PlatformImplementation {
   def isJVM: Boolean = false
   def isJS: Boolean = true
   def isNative: Boolean = false
+
+  lazy val isNodeJS: Boolean = Try(js.Dynamic.global.process.release.name.asInstanceOf[String]).toOption.contains("node")
 
   def init(): Unit = {}
 
@@ -17,7 +21,16 @@ object Platform extends PlatformImplementation {
   def console: JavaScriptConsole = js.Dynamic.global.console.asInstanceOf[JavaScriptConsole]
   // $COVERAGE-ON$
 
-  def outputFormat(): OutputFormat = RichBrowserOutputFormat
+  private def processEnv: Dictionary[Any] = Try(js.Dynamic.global.process.env.asInstanceOf[js.Dictionary[Any]])
+    .getOrElse(js.Dictionary.empty)
+
+  override def env(key: String): Option[String] = processEnv.get(key).map(_.toString)
+
+  override def outputFormat(): OutputFormat = if (isNodeJS) {
+    super.outputFormat()
+  } else {
+    RichBrowserOutputFormat
+  }
 
   override def consoleWriter: Writer = BrowserConsoleWriter
 

--- a/core/js/src/main/scala/scribe/Platform.scala
+++ b/core/js/src/main/scala/scribe/Platform.scala
@@ -13,16 +13,16 @@ object Platform extends PlatformImplementation {
   def isJS: Boolean = true
   def isNative: Boolean = false
 
+  // $COVERAGE-OFF$
   lazy val isNodeJS: Boolean = Try(js.Dynamic.global.process.release.name.asInstanceOf[String]).toOption.contains("node")
 
   def init(): Unit = {}
 
-  // $COVERAGE-OFF$
   def console: JavaScriptConsole = js.Dynamic.global.console.asInstanceOf[JavaScriptConsole]
-  // $COVERAGE-ON$
 
   private def processEnv: Dictionary[Any] = Try(js.Dynamic.global.process.env.asInstanceOf[js.Dictionary[Any]])
     .getOrElse(js.Dictionary.empty)
+  // $COVERAGE-ON$
 
   override def env(key: String): Option[String] = processEnv.get(key).map(_.toString)
 

--- a/core/jvm/src/main/scala/scribe/Platform.scala
+++ b/core/jvm/src/main/scala/scribe/Platform.scala
@@ -37,18 +37,6 @@ object Platform extends PlatformImplementation {
     Moduload.load()
   }
 
-  lazy val supportsANSI: Boolean = sys.env.contains("TERM")
-
-  def outputFormat(): OutputFormat = sys.env.get("SCRIBE_OUTPUT_FORMAT").map(_.toUpperCase) match {
-    case Some("ANSI") => ANSIOutputFormat
-    case Some("ASCII") => ASCIIOutputFormat
-    case None if supportsANSI => ANSIOutputFormat
-    case None => ASCIIOutputFormat
-    case f =>
-      System.err.println(s"Unexpected output format specified in SCRIBE_OUTPUT_FORMAT: $f, using ASCII")
-      ASCIIOutputFormat
-  }
-
   override def consoleWriter: Writer = SystemWriter
 
   override def columns: Int = columnsOverride.getOrElse {

--- a/core/native/src/main/scala/scribe/Platform.scala
+++ b/core/native/src/main/scala/scribe/Platform.scala
@@ -12,18 +12,6 @@ object Platform extends PlatformImplementation {
 
   def init(): Unit = {}
 
-  lazy val supportsANSI: Boolean = sys.env.contains("TERM")
-
-  def outputFormat(): OutputFormat = sys.env.get("SCRIBE_OUTPUT_FORMAT").map(_.toUpperCase) match {
-    case Some("ANSI") => ANSIOutputFormat
-    case Some("ASCII") => ASCIIOutputFormat
-    case None if supportsANSI => ANSIOutputFormat
-    case None => ASCIIOutputFormat
-    case f =>
-      System.err.println(s"Unexpected output format specified in SCRIBE_OUTPUT_FORMAT: $f, using ASCII")
-      ASCIIOutputFormat
-  }
-
   override def consoleWriter: Writer = SystemWriter
 
   override val columns: Int = 120 + columnsAdjust

--- a/core/shared/src/main/scala/scribe/PlatformImplementation.scala
+++ b/core/shared/src/main/scala/scribe/PlatformImplementation.scala
@@ -1,5 +1,6 @@
 package scribe
 
+import scribe.output.format.{ANSIOutputFormat, ASCIIOutputFormat, OutputFormat}
 import scribe.writer.Writer
 
 import scala.concurrent.ExecutionContext
@@ -17,4 +18,18 @@ trait PlatformImplementation {
   def rows: Int
 
   def executionContext: ExecutionContext
+
+  def env(key: String): Option[String] = sys.env.get(key)
+
+  lazy val supportsANSI: Boolean = env("TERM").nonEmpty
+
+  def outputFormat(): OutputFormat = env("SCRIBE_OUTPUT_FORMAT").map(_.toUpperCase) match {
+    case Some("ANSI") => ANSIOutputFormat
+    case Some("ASCII") => ASCIIOutputFormat
+    case None if supportsANSI => ANSIOutputFormat
+    case None => ASCIIOutputFormat
+    case f =>
+      System.err.println(s"Unexpected output format specified in SCRIBE_OUTPUT_FORMAT: $f, using ASCII")
+      ASCIIOutputFormat
+  }
 }


### PR DESCRIPTION
This hopefully cleans up this functionality a bit and adds better detection in Scala.js for the environment.