### PR TITLE
add ISO8601 formatter

### DIFF
--- a/core/shared/src/main/scala/scribe/format/FormatBlock.scala
+++ b/core/shared/src/main/scala/scribe/format/FormatBlock.scala
@@ -77,6 +77,25 @@ object FormatBlock {
         }
       }
     }
+    object ISO8601 extends FormatBlock {
+      private lazy val cache = new ThreadLocal[String] {
+        override def initialValue(): String = ""
+      }
+      private lazy val lastValue = new ThreadLocal[Long] {
+        override def initialValue(): Long = 0L
+      }
+      override def format(record: LogRecord): LogOutput = {
+        val l = record.timeStamp
+        if (l - lastValue.get() > 1000L) {
+          val d = s"${l.t.Y}-${l.t.m}-${l.t.d}T${l.t.T}Z"
+          cache.set(d)
+          lastValue.set(l)
+          new TextOutput(d)
+        } else {
+          new TextOutput(cache.get())
+        }
+      }
+    }
     object Full extends FormatBlock {
       override def format(record: LogRecord): LogOutput = {
         val l = record.timeStamp


### PR DESCRIPTION
Sorry for taking so long. I went back and forth on if I should implement a more general trait to be the shared base of this and the `Date.Standard` formatter as they share all but one line of code. In the end I decided against it for unconfirmed performance reasons.

I also considered making the sub-second resolution configurable by making it a class rather than an object — `java.time.Instant` admits to millisecond, microsecond and nanosecond precisions — but again decided not to for performance reasons (`LogRecord.timeStamp` holding milliseconds since epoch was also a hindrance.)