### PR TITLE
Switch the default formatter to the real one

### DIFF
--- a/core/shared/src/main/scala/scribe/format/Formatter.scala
+++ b/core/shared/src/main/scala/scribe/format/Formatter.scala
@@ -69,7 +69,7 @@ object Formatter {
    * The default formatter. This is used as a default when the formatter isn't explicitly specified. Defaults to
    * enhanced.
    */
-  var default: Formatter = advanced
+  var default: Formatter = enhanced
 
   def fromBlocks(blocks: FormatBlock*): Formatter = new FormatBlocksFormatter(blocks.toList)
 }


### PR DESCRIPTION
The docstring is telling us that the default is `enhanced`, whereas the code is using the advanced one.
Moreover most of the users expect a log library to output single line message without any configuration.