### PR TITLE
Scala native 0.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ out/
 benchmarks.json
 lowered.hnir
 *.iml
+.bloop
+project/project
+project/metals.sbt
+.metals

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.15.0")
 
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")
 


### PR DESCRIPTION
Scala Native 0.5 is released, the recommendation is to not cross-publish and instead cut over straight to 0.5