### PR TITLE
Fix `scala-collection-compat` for Scala Native

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ val perfolationVersion: String = "1.2.11"
 
 val sourcecodeVersion: String = "0.4.2"
 
-val collectionCompatVersion: String = "2.11.0"
+val collectionCompatVersion: String = "2.12.0"
 
 val moduloadVersion: String = "1.1.7"
 
@@ -123,10 +123,10 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       "org.scalatest" %% "scalatest" % scalaTestVersion % Test
     ),
     libraryDependencies ++= (
-      if (scalaVersion.value.startsWith("3.0")) {
-        Nil
+      if (scalaVersion.value.startsWith("2.12.")) {
+        List("org.scala-lang.modules" %%% "scala-collection-compat" % collectionCompatVersion)
       } else {
-        List("org.scala-lang.modules" %% "scala-collection-compat" % collectionCompatVersion)
+        Nil
       }
     ),
     Test / publishArtifact := false,
@@ -153,10 +153,10 @@ lazy val cats = crossProject(JVMPlatform, JSPlatform) //, NativePlatform)
       "org.typelevel" %% "cats-effect-testing-scalatest" % catsEffectTestingVersion % "test"
     ),
     libraryDependencies ++= (
-      if (scalaVersion.value.startsWith("3.0")) {
-        Nil
+      if (scalaVersion.value.startsWith("2.12.")) {
+        List("org.scala-lang.modules" %%% "scala-collection-compat" % collectionCompatVersion)
       } else {
-        List("org.scala-lang.modules" %% "scala-collection-compat" % collectionCompatVersion)
+        Nil
       }
     ),
     Test / publishArtifact := false


### PR DESCRIPTION
`scala-collection-compat` was declared with `%%` which doesn't carry the `.nir` files necessary for Scala Native.
Moreover, it was always added since the correct switch should be `scalaVersion.startsWith("2.12.")` not `!scalaVersion.startsWith("3.0")`

### Workaround

Until this gets merged and published you can exclude the wrong `scala-collection-compat` artifact and manually add the correct version to your `libraryDependencies`

```scala
libraryDependencies ++= Seq(
  ("com.outr" %%% "scribe" % "3.14.0")
    .excludeAll("org.scala-lang.modules" %% "scala-collection-compat")
)

libraryDependencies ++= (
  if (scalaVersion.value.startsWith("2.12.")) {
    List("org.scala-lang.modules" %%% "scala-collection-compat" % "2.12.0")
  } else {
    Nil
  }
)
```