### PR TITLE
Fixes SlackWriter to evaluate the IO.

### DIFF
--- a/logstash/src/main/scala/scribe/logstash/LogstashWriter.scala
+++ b/logstash/src/main/scala/scribe/logstash/LogstashWriter.scala
@@ -23,7 +23,7 @@ case class LogstashWriter(url: URL,
   private lazy val client = HttpClient.url(url).post
 
   override def write(record: LogRecord, output: LogOutput, outputFormat: OutputFormat): Unit = {
-    val io = log(record)
+    val io = log(record) // Does nothing
     if (!asynchronous) {
       io.unsafeRunSync()
     }

--- a/slack/src/main/scala/scribe/slack/SlackWriter.scala
+++ b/slack/src/main/scala/scribe/slack/SlackWriter.scala
@@ -12,8 +12,10 @@ import scribe.writer.Writer
   * @param emojiIcon the emoji to use when sending messages
   */
 class SlackWriter(slack: Slack, emojiIcon: String) extends Writer {
+  import cats.effect.unsafe.implicits.global
+
   override def write(record: LogRecord, output: LogOutput, outputFormat: OutputFormat): Unit = slack.request(
     message = output.plainText,
     emojiIcon = emojiIcon
-  )
+  ).unsafeRunAndForget()
 }

--- a/slack/src/main/scala/scribe/slack/SlackWriter.scala
+++ b/slack/src/main/scala/scribe/slack/SlackWriter.scala
@@ -4,6 +4,7 @@ import scribe.LogRecord
 import scribe.output.LogOutput
 import scribe.output.format.OutputFormat
 import scribe.writer.Writer
+import cats.effect.unsafe.implicits.global
 
 /**
   * SlackWriter is
@@ -12,10 +13,10 @@ import scribe.writer.Writer
   * @param emojiIcon the emoji to use when sending messages
   */
 class SlackWriter(slack: Slack, emojiIcon: String) extends Writer {
-  import cats.effect.unsafe.implicits.global
 
   override def write(record: LogRecord, output: LogOutput, outputFormat: OutputFormat): Unit = slack.request(
     message = output.plainText,
     emojiIcon = emojiIcon
   ).unsafeRunAndForget()
+
 }


### PR DESCRIPTION
This uses unsafeRunAndForget. This is not ideal, but currently there is no way to wire up an effectfull writer as far as I can tell. An effectfull writer would also need to be wired up in the application (maybe some would prefer this).